### PR TITLE
persistence of dialog state and events to dynamoDB

### DIFF
--- a/dialog/dialog.py
+++ b/dialog/dialog.py
@@ -1,14 +1,16 @@
 import uuid
-from typing import List
+from typing import List, Dict, Any
+
+from marshmallow import fields, post_load
 
 from drills import drills
 from .persistence import DialogRepository, DynamoDBDialogRepository
-from .types import Command, DialogState, DialogEvent, DialogEventType, PromptState
+from . import types
 
 VALID_OPT_IN_CODES = {"drill0"}
 
 
-def process_command(command: Command, repo: DialogRepository = None):
+def process_command(command: types.Command, repo: DialogRepository = None):
     if repo is None:
         repo = DynamoDBDialogRepository()
     dialog_state = repo.fetch_dialog_state(command.phone_number)
@@ -18,36 +20,22 @@ def process_command(command: Command, repo: DialogRepository = None):
     repo.persist_dialog_state(events, dialog_state)
 
 
-class StartDrill(Command):
+class StartDrill(types.Command):
     def __init__(self, phone_number: str, drill: drills.Drill):
         super().__init__(phone_number)
         self.drill = drill
 
-    def execute(self, dialog_state: DialogState) -> List[DialogEvent]:
+    def execute(self, dialog_state: types.DialogState) -> List[types.DialogEvent]:
         return [DrillStarted(self.phone_number, self.drill)]
 
 
-class DrillStarted(DialogEvent):
-    def __init__(self, phone_number: str, drill: drills.Drill):
-        super().__init__(DialogEventType.DRILL_STARTED, phone_number)
-        self.drill = drill
-        self.prompt = drill.first_prompt()
-
-    def apply_to(self, dialog_state: DialogState):
-        dialog_state.current_drill = self.drill
-        dialog_state.current_prompt_state = PromptState(
-            self.prompt.slug,
-            start_time=self.created_time
-        )
-
-
-class TriggerReminder(Command):
+class TriggerReminder(types.Command):
     def __init__(self, phone_number: str, drill_id: uuid.UUID, prompt_slug: str):
         super().__init__(phone_number)
         self.prompt_slug = prompt_slug
         self.drill_id = drill_id
 
-    def execute(self, dialog_state: DialogState) -> List[DialogEvent]:
+    def execute(self, dialog_state: types.DialogState) -> List[types.DialogEvent]:
         drill = dialog_state.current_drill
         if drill is None or drill.drill_id != self.drill_id:
             return []
@@ -63,21 +51,13 @@ class TriggerReminder(Command):
         return [ReminderTriggered(self.phone_number)]
 
 
-class ReminderTriggered(DialogEvent):
-    def __init__(self, phone_number: str):
-        super().__init__(DialogEventType.REMINDER_TRIGGERED, phone_number)
-
-    def apply_to(self, dialog_state: DialogState):
-        dialog_state.current_prompt_state.reminder_triggered = True
-
-
-class ProcessSMSMessage(Command):
+class ProcessSMSMessage(types.Command):
     def __init__(self, phone_number: str, content: str):
         super().__init__(phone_number)
         self.content = content.strip()
         self.content_lower = self.content.lower()
 
-    def execute(self, dialog_state: DialogState) -> List[DialogEvent]:
+    def execute(self, dialog_state: types.DialogState) -> List[types.DialogEvent]:
         if not dialog_state.user_profile.validated:
             if self.content_lower in VALID_OPT_IN_CODES:
                 return [UserCreated(self.phone_number)]
@@ -104,64 +84,207 @@ class ProcessSMSMessage(Command):
         return events
 
 
-class UserCreated(DialogEvent):
-    def __init__(self, phone_number: str):
-        super().__init__(DialogEventType.USER_CREATED, phone_number)
+class DrillStartedSchema(types.DialogEventSchema):
+    drill = fields.Nested(drills.DrillSchema, required=True)
 
-    def apply_to(self, dialog_state: DialogState):
+    @post_load
+    def make_drill_started(self, data, **kwargs):
+        return DrillStarted(**data)
+
+
+class DrillStarted(types.DialogEvent):
+    def __init__(self, phone_number: str, drill: drills.Drill, **kwargs):
+        super().__init__(
+            DrillStartedSchema(),
+            types.DialogEventType.DRILL_STARTED,
+            phone_number,
+            **kwargs
+        )
+        self.drill = drill
+        self.prompt = drill.first_prompt()
+
+    def apply_to(self, dialog_state: types.DialogState):
+        dialog_state.current_drill = self.drill
+        dialog_state.current_prompt_state = types.PromptState(
+            self.prompt.slug,
+            start_time=self.created_time
+        )
+
+
+class ReminderTriggeredSchema(types.DialogEventSchema):
+    @post_load
+    def make_reminder_triggered(self, data, **kwargs):
+        return ReminderTriggered(**data)
+
+
+class ReminderTriggered(types.DialogEvent):
+    def __init__(self, phone_number: str, **kwargs):
+        super().__init__(
+            ReminderTriggeredSchema(),
+            types.DialogEventType.REMINDER_TRIGGERED,
+            phone_number,
+            **kwargs
+        )
+
+    def apply_to(self, dialog_state: types.DialogState):
+        dialog_state.current_prompt_state.reminder_triggered = True
+
+
+class UserCreatedSchema(types.DialogEventSchema):
+    @post_load
+    def make_user_created(self, data, **kwargs):
+        return UserCreated(**data)
+
+
+class UserCreated(types.DialogEvent):
+    def __init__(self, phone_number: str, **kwargs):
+        super().__init__(
+            UserCreatedSchema(),
+            types.DialogEventType.USER_CREATED,
+            phone_number,
+            **kwargs
+        )
+
+    def apply_to(self, dialog_state: types.DialogState):
         dialog_state.user_profile.validated = True
 
 
-class UserCreationFailed(DialogEvent):
-    def __init__(self, phone_number: str):
-        super().__init__(DialogEventType.USER_CREATION_FAILED, phone_number)
+class UserCreationFailedSchema(types.DialogEventSchema):
+    @post_load
+    def make_user_creation_failed(self, data, **kwargs):
+        return UserCreationFailed(**data)
 
-    def apply_to(self, dialog_state: DialogState):
+
+class UserCreationFailed(types.DialogEvent):
+    def __init__(self, phone_number: str, **kwargs):
+        super().__init__(
+            UserCreationFailedSchema(),
+            types.DialogEventType.USER_CREATION_FAILED,
+            phone_number,
+            **kwargs
+        )
+
+    def apply_to(self, dialog_state: types.DialogState):
         pass
 
 
-class CompletedPrompt(DialogEvent):
-    def __init__(self, phone_number: str, prompt: drills.Prompt, response: str):
-        super().__init__(DialogEventType.COMPLETED_PROMPT, phone_number)
+class CompletedPromptSchema(types.DialogEventSchema):
+    prompt = fields.Nested(drills.PromptSchema, required=True)
+    response = fields.String(required=True)
+
+    @post_load
+    def make_completed_prompt(self, data, **kwargs):
+        return CompletedPrompt(**data)
+
+
+class CompletedPrompt(types.DialogEvent):
+    def __init__(self, phone_number: str, prompt: drills.Prompt, response: str, **kwargs):
+        super().__init__(
+            CompletedPromptSchema(),
+            types.DialogEventType.COMPLETED_PROMPT,
+            phone_number,
+            **kwargs
+        )
         self.prompt = prompt
         self.response = response
 
-    def apply_to(self, dialog_state: DialogState):
+    def apply_to(self, dialog_state: types.DialogState):
         dialog_state.current_prompt_state = None
         if self.prompt.response_user_profile_key:
             setattr(dialog_state.user_profile, self.prompt.response_user_profile_key, self.response)
 
 
-class FailedPrompt(DialogEvent):
-    def __init__(self, phone_number: str, prompt: drills.Prompt, abandoned: bool):
-        super().__init__(DialogEventType.FAILED_PROMPT, phone_number)
+class FailedPromptSchema(types.DialogEventSchema):
+    prompt = fields.Nested(drills.PromptSchema, required=True)
+    abandoned = fields.Boolean(required=True)
+
+    @post_load
+    def make_failed_prompt(self, data, **kwargs):
+        return FailedPrompt(**data)
+
+
+class FailedPrompt(types.DialogEvent):
+    def __init__(self, phone_number: str, prompt: drills.Prompt, abandoned: bool, **kwargs):
+        super().__init__(
+            FailedPromptSchema(),
+            types.DialogEventType.FAILED_PROMPT,
+            phone_number,
+            **kwargs
+        )
         self.prompt = prompt
         self.abandoned = abandoned
 
-    def apply_to(self, dialog_state: DialogState):
+    def apply_to(self, dialog_state: types.DialogState):
         if self.abandoned:
             dialog_state.current_prompt_state = None
         else:
             dialog_state.current_prompt_state.failures += 1
 
 
-class AdvancedToNextPrompt(DialogEvent):
-    def __init__(self, phone_number: str, prompt: drills.Prompt):
-        super().__init__(DialogEventType.ADVANCED_TO_NEXT_PROMPT, phone_number)
+class AdvancedToNextPromptSchema(types.DialogEventSchema):
+    prompt = fields.Nested(drills.PromptSchema, required=True)
+
+    @post_load
+    def make_advanced_to_next_prompt(self, data, **kwargs):
+        return AdvancedToNextPrompt(**data)
+
+
+class AdvancedToNextPrompt(types.DialogEvent):
+    def __init__(self, phone_number: str, prompt: drills.Prompt, **kwargs):
+        super().__init__(
+            AdvancedToNextPromptSchema(),
+            types.DialogEventType.ADVANCED_TO_NEXT_PROMPT,
+            phone_number,
+            **kwargs
+        )
         self.prompt = prompt
 
-    def apply_to(self, dialog_state: DialogState):
-        dialog_state.current_prompt_state = PromptState(
+    def apply_to(self, dialog_state: types.DialogState):
+        dialog_state.current_prompt_state = types.PromptState(
             self.prompt.slug,
             start_time=self.created_time
         )
 
 
-class DrillCompleted(DialogEvent):
-    def __init__(self, phone_number: str, drill: drills.Drill):
-        super().__init__(DialogEventType.DRILL_COMPLETED, phone_number)
+class DrillCompletedSchema(types.DialogEventSchema):
+    drill = fields.Nested(drills.DrillSchema, required=True)
+
+    @post_load
+    def make_drill_completed(self, data, **kwargs):
+        return DrillCompleted(**data)
+
+
+class DrillCompleted(types.DialogEvent):
+    def __init__(self, phone_number: str, drill: drills.Drill, **kwargs):
+        super().__init__(
+            DrillCompletedSchema(),
+            types.DialogEventType.DRILL_COMPLETED,
+            phone_number,
+            **kwargs
+        )
         self.drill = drill
 
-    def apply_to(self, dialog_state: DialogState):
+    def apply_to(self, dialog_state: types.DialogState):
         dialog_state.completed_drills.append(dialog_state.current_drill)
         dialog_state.current_drill = None
+
+
+def to_event(event_dict: Dict[str, Any]) -> types.DialogEvent:
+    event_type = types.DialogEventType[event_dict['event_type']]
+    if event_type == types.DialogEventType.ADVANCED_TO_NEXT_PROMPT:
+        return AdvancedToNextPromptSchema().load(event_dict)
+    if event_type == types.DialogEventType.DRILL_COMPLETED:
+        return DrillCompletedSchema().load(event_dict)
+    if event_type == types.DialogEventType.USER_CREATION_FAILED:
+        return UserCreationFailedSchema().load(event_dict)
+    if event_type == types.DialogEventType.DRILL_STARTED:
+        return DrillStartedSchema().load(event_dict)
+    if event_type == types.DialogEventType.USER_CREATED:
+        return UserCreatedSchema().load(event_dict)
+    if event_type == types.DialogEventType.COMPLETED_PROMPT:
+        return CompletedPromptSchema().load(event_dict)
+    if event_type == types.DialogEventType.FAILED_PROMPT:
+        return FailedPromptSchema().load(event_dict)
+    if event_type == types.DialogEventType.REMINDER_TRIGGERED:
+        return ReminderTriggeredSchema().load(event_dict)
+    raise ValueError(f"unknown event type {event_type}")

--- a/dialog/persistence.py
+++ b/dialog/persistence.py
@@ -3,8 +3,9 @@ from abc import ABC, abstractmethod
 from typing import List
 
 import boto3
+from boto3.dynamodb.types import TypeSerializer, TypeDeserializer
 
-from .types import DialogState, DialogEvent
+from .types import DialogState, DialogEvent, DialogStateSchema
 
 
 class DialogRepository(ABC):
@@ -19,7 +20,7 @@ class DialogRepository(ABC):
 
 class DynamoDBDialogRepository(DialogRepository):
     def __init__(self, table_name_suffix=None):
-        self.dynamodb = boto3.resource("dynamodb")
+        self.dynamodb = boto3.client("dynamodb")
         if table_name_suffix is None:
             table_name_suffix = os.getenv("DIALOG_TABLE_NAME_SUFFIX", "")
         self.table_name_suffix = table_name_suffix
@@ -33,10 +34,34 @@ class DynamoDBDialogRepository(DialogRepository):
                 else "dialog-state")
 
     def fetch_dialog_state(self, phone_number: str) -> DialogState:
-        pass
+        response = self.dynamodb.get_item(
+            TableName=self.state_table_name(),
+            Key={
+                "phone_number": {
+                    "S": phone_number
+                }
+            },
+            ConsistentRead=True
+        )
+        dialog_dict = _deserialize(response['Item'])
+        return DialogStateSchema().load(dialog_dict)
 
     def persist_dialog_state(self, events: List[DialogEvent], dialog_state: DialogState):
-        pass
+        write_items = []
+        for event in events:
+            write_items.append({
+                "Put": {
+                    "TableName": self.events_table_name(),
+                    "Item": _serialize(event.to_dict())
+                }
+            })
+        write_items.append({
+            "Put": {
+                "TableName": self.state_table_name(),
+                "Item": _serialize(dialog_state.to_dict())
+            }
+        })
+        self.dynamodb.transact_write_items(TransactItems=write_items)
 
     def create_tables(self):
         # useful for testing but will likely be duplicated elsewhere
@@ -104,3 +129,13 @@ class DynamoDBDialogRepository(DialogRepository):
             ],
             BillingMode="PAY_PER_REQUEST"
         )
+
+
+def _serialize(a_dict):
+    serializer = TypeSerializer()
+    return {k: serializer.serialize(v) for k, v in a_dict.items()}
+
+
+def _deserialize(a_dict):
+    deserializer = TypeDeserializer()
+    return {k: deserializer.deserialize(v) for k, v in a_dict.items()}

--- a/dialog/test_dialog.py
+++ b/dialog/test_dialog.py
@@ -1,0 +1,101 @@
+import unittest
+
+from drills.drills import Prompt, Drill
+from .dialog import *
+from .types import DialogEvent
+
+"""
+    DRILL_COMPLETED = "DRILL_COMPLETED"
+"""
+
+
+class TestSerialization(unittest.TestCase):
+    def setUp(self) -> None:
+        self.prompt = Prompt(
+            slug='my-prompt',
+            messages=['one', 'two']
+        )
+        self.drill = Drill(
+            drill_id=uuid.uuid4(),
+            prompts=[self.prompt]
+        )
+
+    def _make_base_assertions(self, original: DialogEvent, deserialized: DialogEvent):
+        self.assertEqual(original.event_id, deserialized.event_id)
+        self.assertEqual(original.event_type, deserialized.event_type)
+        self.assertEqual(original.phone_number, deserialized.phone_number)
+        self.assertEqual(original.created_time, deserialized.created_time)
+
+    def test_advanced_to_next_prompt(self):
+        original = AdvancedToNextPrompt(
+            phone_number="123456789",
+            prompt=self.prompt
+        )
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+        self.assertEqual(original.prompt.slug, deserialized.prompt.slug)
+
+    def test_completed_prompt(self):
+        original = CompletedPrompt(
+            phone_number="123456789",
+            prompt=self.prompt,
+            response="hello"
+        )
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+        self.assertEqual(original.prompt.slug, deserialized.prompt.slug)
+        self.assertEqual(original.response, deserialized.response)
+
+    def test_failed_prompt(self):
+        original = FailedPrompt(
+            phone_number="123456789",
+            prompt=self.prompt,
+            response="hello",
+            abandoned=True
+        )
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+        self.assertEqual(original.prompt.slug, deserialized.prompt.slug)
+        self.assertEqual(original.response, deserialized.response)
+        self.assertEqual(original.abandoned, deserialized.abandoned)
+
+    def test_drill_started(self):
+        original = DrillStarted(
+            phone_number="12345678",
+            drill=self.drill
+        )
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+        self.assertEqual(original.drill.drill_id, deserialized.drill.drill_id)
+
+    def test_drill_completed(self):
+        original = DrillCompleted(
+            phone_number="12345678",
+            drill=self.drill
+        )
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+        self.assertEqual(original.drill.drill_id, deserialized.drill.drill_id)
+
+    def test_reminder_triggered(self):
+        original = ReminderTriggered("123456789")
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+
+    def test_user_created(self):
+        original = UserCreated("123456789")
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+
+    def test_user_creation_failed(self):
+        original = UserCreationFailed("123456789")
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)

--- a/dialog/test_dialog.py
+++ b/dialog/test_dialog.py
@@ -4,10 +4,6 @@ from drills.drills import Prompt, Drill
 from .dialog import *
 from .types import DialogEvent
 
-"""
-    DRILL_COMPLETED = "DRILL_COMPLETED"
-"""
-
 
 class TestSerialization(unittest.TestCase):
     def setUp(self) -> None:

--- a/dialog/test_persistence.py
+++ b/dialog/test_persistence.py
@@ -1,0 +1,55 @@
+import unittest
+
+from dialog.dialog import CompletedPrompt, AdvancedToNextPrompt
+from dialog.persistence import DynamoDBDialogRepository
+from dialog.types import DialogState, UserProfile
+from drills.drills import Prompt
+
+
+class TestPersistence(unittest.TestCase):
+    """
+    requires local dynamoDB to be running: docker-compose up in the dynamodb_local directory
+    """
+
+    def setUp(self):
+        self.repo = DynamoDBDialogRepository(
+            region_name="us-west-2",
+            endpoint_url="http://localhost:9000",
+        )
+        self.repo.ensure_tables_exist()
+        self.phone_number = "123456789"
+
+    def test_save_and_fetch(self):
+        dialog_state = self.repo.fetch_dialog_state(self.phone_number)
+        self.assertEqual(self.phone_number, dialog_state.phone_number)
+
+        event1 = CompletedPrompt(
+            phone_number=self.phone_number,
+            prompt=Prompt(
+                slug="one",
+                messages=["one", "two"]
+            ),
+            response="hi"
+        )
+        event2 = AdvancedToNextPrompt(
+            phone_number=self.phone_number,
+            prompt=Prompt(
+                slug="two",
+                messages=["three", "four"]
+            )
+        )
+        dialog_state = DialogState(
+            self.phone_number,
+            user_profile=UserProfile(validated=True, language="de")
+        )
+        self.repo.persist_dialog_state([event1, event2], dialog_state)
+        dialog_state2 = self.repo.fetch_dialog_state(self.phone_number)
+        self.assertEqual(dialog_state.phone_number, dialog_state2.phone_number)
+        self.assertEqual(dialog_state.user_profile.validated, dialog_state2.user_profile.validated)
+        self.assertEqual(dialog_state.user_profile.language, dialog_state2.user_profile.language)
+
+        event1_retrieved = self.repo.fetch_dialog_event(self.phone_number, event1.event_id)
+        self.assertEqual(event1.response, event1_retrieved.response)
+
+        event2_retrieved = self.repo.fetch_dialog_event(self.phone_number, event2.event_id)
+        self.assertEqual(event2.prompt.slug, event2_retrieved.prompt.slug)

--- a/dialog/types.py
+++ b/dialog/types.py
@@ -109,11 +109,23 @@ class DialogEventType(enum.Enum):
     DRILL_COMPLETED = "DRILL_COMPLETED"
 
 
+class EventTypeField(fields.Field):
+    """Field that serializes to a title case string and deserializes
+    to a lower case string.
+    """
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        return value.name
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        return DialogEventType[value]
+
+
 class DialogEventSchema(Schema):
     phone_number = fields.String(required=True)
     created_time = fields.DateTime(required=True)
     event_id = fields.UUID(required=True)
-    event_type = fields.String(required=True)
+    event_type = EventTypeField(required=True)
 
 
 class DialogEvent(ABC):

--- a/dialog/types.py
+++ b/dialog/types.py
@@ -2,7 +2,7 @@ import enum
 import uuid
 from abc import abstractmethod, ABC
 import datetime
-from typing import Optional, List
+from typing import Optional, List, Dict
 
 from marshmallow import Schema, fields, post_load
 from drills import drills
@@ -94,6 +94,9 @@ class DialogState:
     def is_next_prompt_last(self) -> bool:
         return self.current_drill.prompts[-1].slug == self.get_next_prompt().slug
 
+    def to_dict(self) -> Dict:
+        return DialogStateSchema().dump(self)
+
 
 class DialogEventType(enum.Enum):
     DRILL_STARTED = "DRILL_STARTED"
@@ -106,20 +109,31 @@ class DialogEventType(enum.Enum):
     DRILL_COMPLETED = "DRILL_COMPLETED"
 
 
+class DialogEventSchema(Schema):
+    phone_number = fields.String(required=True)
+    created_time = fields.DateTime(required=True)
+    event_id = fields.UUID(required=True)
+    event_type = fields.String(required=True)
+
+
 class DialogEvent(ABC):
-    def __init__(self, event_type: DialogEventType, phone_number: str):
+    def __init__(self, schema: Schema, event_type: DialogEventType, phone_number: str, **kwargs):
+        self.schema = schema
         self.phone_number = phone_number
 
         # relying on created time to determine ordering. We should be fine and it's simpler than
         # sequence numbers. Events are processed in order by phone number and are relatively
         # infrequent. And the lambda environment has some clock guarantees.
-        self.created_time = datetime.datetime.utcnow()
-        self.event_id = uuid.uuid4()
+        self.created_time = kwargs.get('created_time', datetime.datetime.utcnow())
+        self.event_id = kwargs.get('event_id', uuid.uuid4())
         self.event_type = event_type
 
     @abstractmethod
     def apply_to(self, dialog_state: DialogState):
         pass
+
+    def to_dict(self) -> Dict:
+        return self.schema.dump(self)
 
 
 class Command(ABC):

--- a/dynamodb_local/Dockerfile
+++ b/dynamodb_local/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:8
+RUN mkdir -p opt/dynamodb
+WORKDIR /opt/dynamodb
+RUN wget https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz -q -O - | tar -xz
+EXPOSE 8000
+ENTRYPOINT ["java", "-jar", "DynamoDBLocal.jar"]

--- a/dynamodb_local/docker-compose.yml
+++ b/dynamodb_local/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.1'
+
+services:
+  dynamo:
+    build: .
+    ports:
+      - 9000:8000
+    command:
+      -inMemory

--- a/simulator.py
+++ b/simulator.py
@@ -4,9 +4,9 @@ from time import sleep
 from typing import List
 
 from dialog.dialog import (
-    DialogEvent, DialogState, DialogRepository, process_command, StartDrill, ProcessSMSMessage
+    DialogRepository, process_command, StartDrill, ProcessSMSMessage
 )
-from dialog.types import DialogStateSchema, DialogEventType
+from dialog.types import DialogStateSchema, DialogEventType, DialogEvent, DialogState
 from drills.drills import Drill, Prompt
 
 TRY_AGAIN = "Sorry, not correct.\n\n*Try again one more time!*"


### PR DESCRIPTION
I've tested locally using the local client (docker-compose up from the dynamodb local directory to run it). I could use some help on configuring this stuff in serverless.

Most of the work was enabling serialization of DialogEvents.