### PR TITLE
Increase timeout of logMessage lambda to account for aurora cold starts

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -53,7 +53,7 @@ functions:
 
   logMessage:
     handler: message_log.log_message
-    timeout: 20  # Aurora cold starts take some time
+    timeout: 20  # Give aurora cluster time to cold start
 
   healthcheck:
     handler: healthcheck.healthcheck

--- a/serverless.yml
+++ b/serverless.yml
@@ -53,6 +53,7 @@ functions:
 
   logMessage:
     handler: message_log.log_message
+    timeout: 20  # Aurora cold starts take some time
 
   healthcheck:
     handler: healthcheck.healthcheck


### PR DESCRIPTION
Aurora cold starts take a long time. Right now the lambda fails twice at a 6 second timeout and succeeds on the third retry. Bumping up to 20 seconds should make the lambda succeed on the first try.