### PR TITLE
New drills and translations

### DIFF
--- a/stopcovid/drills/drill_content/drills.json
+++ b/stopcovid/drills/drill_content/drills.json
@@ -3,37 +3,37 @@
     "name": "01. COVID19: Basics",
     "prompts": [
       {
-        "slug": "0 - Intake",
+        "slug": "00 - Intake",
         "messages": [
           "Welcome! Choose your language:\nen - English\nes - Español\nfr - Français\npt - Português\nzh - Chinese 中文"
         ],
         "response_user_profile_key": "language"
       },
       {
-        "slug": "00 - GO",
+        "slug": "01 - GO",
         "messages": [
           "{{stop_covid_thanks}}",
           "{{drill_intro_2}} {{covid_1_title}}. {{text_go}}"
         ]
       },
       {
-        "slug": "01.2 - Name",
+        "slug": "02 - Self assessment",
+        "messages": [
+          "{{drill_self_assess_1}}",
+          "{{drill_self_assess_2}} {{covid_1_title}}. \n\n{{likert_1_10_knowledge}}",
+          "{{drill_self_assess_3}}"
+        ],
+        "response_user_profile_key": "self_rating_1"
+      },
+      {
+        "slug": "03 - Name",
         "messages": [
           "{{intake_whats_your_full_name}}"
         ],
         "response_user_profile_key": "name"
       },
       {
-        "slug": "01 - Self assessment",
-        "messages": [
-          "{{drill_self_assess_3}}",
-          "{{drill_self_assess_2}} {{covid_1_title}}. \n\n{{likert_1_10_knowledge}}",
-          "{{drill_self_assess_1}}"
-        ],
-        "response_user_profile_key": "self_rating_1"
-      },
-      {
-        "slug": "02 - Q1",
+        "slug": "04 - Q1",
         "messages": [
           "{{thank_you}}",
           "{{drill_practice_caps}} 1: {{covid_1_practice_1}}"
@@ -41,43 +41,43 @@
         "correct_response": "b) {{false}}"
       },
       {
-        "slug": "03 - Q2",
+        "slug": "05 - Q2",
         "messages": [
-          "{{drill_practice_caps}} 2: {{covid_1_practice_2}}",
-          "{{covid_1_fact_1}}"
+          "{{covid_1_fact_1}}",
+          "{{drill_practice_caps}} 2: {{covid_1_practice_2}}"
         ],
         "correct_response": "c) {{more_contagious_than}}"
       },
       {
-        "slug": "04 - Q3",
+        "slug": "06 - Q3",
         "messages": [
-          "{{drill_practice_caps}} 3: {{covid_1_practice_3}}",
-          "{{covid_1_fact_2}}"
+          "{{covid_1_fact_2}}",
+          "{{drill_practice_caps}} 3: {{covid_1_practice_3}}"
         ],
         "correct_response": "d) {{all_of_the_above}}"
       },
       {
-        "slug": "05 - Q4",
+        "slug": "07 - Q4",
         "messages": [
-          "{{drill_practice_caps}} 4: {{covid_1_practice_4}}",
-          "{{covid_1_fact_3}}"
+          "{{covid_1_fact_3}}",
+          "{{drill_practice_caps}} 4: {{covid_1_practice_4}}"
         ],
         "correct_response": "b) {{fever_cough_shortness_of_breath}}"
       },
       {
-        "slug": "06 - Q5",
+        "slug": "08 - Q5",
         "messages": [
           "{{almost_done}}",
-          "{{drill_practice_caps}} 5: {{covid_1_practice_5}}",
-          "{{covid_1_fact_4}}"
+          "{{covid_1_fact_4}}",
+          "{{drill_practice_caps}} 5: {{covid_1_practice_5}}"
         ],
         "correct_response": "d) {{all_of_the_above}}"
       },
       {
-        "slug": "07 - Celebration",
+        "slug": "09 - Celebration",
         "messages": [
-          "{{drill_complete_congrats}}\n\n{{drill_complete_next}}",
-          "{{covid_1_fact_5}}"
+          "{{covid_1_fact_5}}",
+          "{{drill_complete_congrats}}\n\n{{drill_complete_next}}"
         ]
       }
     ]
@@ -94,49 +94,49 @@
       {
         "slug": "01 - Self assessment",
         "messages": [
-          "{{drill_self_assess_3}}",
+          "{{drill_self_assess_1}}",
           "{{drill_self_assess_2}}{{covid_2_title}}.\n\n{{likert_1_10_knowledge}}",
-          "{{drill_self_assess_1}}"
+          "{{drill_self_assess_3}}"
         ],
         "response_user_profile_key": "self_rating_2"
       },
       {
         "slug": "02 - Q1",
         "messages": [
-          "{{drill_practice_caps}} 1: {{covid_prev_practice_1}}",
-          "{{thank_you}}"
+          "{{thank_you}}",
+          "{{drill_practice_caps}} 1: {{covid_prev_practice_1}}"
         ],
         "correct_response": "b) {{avoid_being_exposed_to_the_virus}}"
       },
       {
         "slug": "03 - Q2",
         "messages": [
-          "{{drill_practice_caps}} 2: \n\n{{covid_prev_practice_2}}",
-          "{{covid_prev_fact_1}}"
+          "{{covid_prev_fact_1}}",
+          "{{drill_practice_caps}} 2: \n\n{{covid_prev_practice_2}}"
         ],
         "correct_response": "d) {{all_of_the_above}}"
       },
       {
         "slug": "04 - Q3",
         "messages": [
-          "{{drill_practice_caps}} 3: \n\n{{covid_prev_practice_3}}",
-          "{{covid_prev_fact_2}}"
+          "{{covid_prev_fact_2}}",
+          "{{drill_practice_caps}} 3: \n\n{{covid_prev_practice_3}}"
         ],
         "correct_response": "c) {{days_after_exposure}}"
       },
       {
         "slug": "05 - Q4",
         "messages": [
-          "{{drill_practice_caps}} 4: \n\n{{covid_prev_practice_4}}",
-          "{{covid_prev_fact_3}}"
+          "{{covid_prev_fact_3}}",
+          "{{drill_practice_caps}} 4: \n\n{{covid_prev_practice_4}}"
         ],
         "correct_response": "d) {{all_of_the_above}}"
       },
       {
         "slug": "06 - Q5",
         "messages": [
-          "{{drill_practice_caps}} 5:\n\n{{covid_prev_practice_5}}",
-          "{{covid_prev_fact_4}}"
+          "{{covid_prev_fact_4}}",
+          "{{drill_practice_caps}} 5:\n\n{{covid_prev_practice_5}}"
         ],
         "correct_response": "a) {{true}}"
       },
@@ -161,8 +161,8 @@
         "slug": "3 - self assessment - #",
         "messages": [
           "{{drill_self_assess_1}}",
-          "{{drill_self_assess_3}}",
-          "{{drill_self_assess_2}} {{covid_3_title}}\n\n{{likert_1_10_knowledge}}"
+          "{{drill_self_assess_2}} {{covid_3_title}}\n\n{{likert_1_10_knowledge}}",
+          "{{drill_self_assess_3}}"
         ],
         "response_user_profile_key": "self_rating_3"
       },
@@ -185,8 +185,8 @@
       {
         "slug": "6 - Practice 3 (FIB_MCQ3)",
         "messages": [
-          "{{drill_practice_caps}} 3: {{drill_how_to_practice_3}}",
-          "{{drill_how_to_fact_3}}"
+          "{{drill_how_to_fact_3}}",
+          "{{drill_practice_caps}} 3: {{drill_how_to_practice_3}}"
         ],
         "correct_response": "c) {{your_fingers_and_under_your_fingernails}}"
       },
@@ -201,9 +201,9 @@
       {
         "slug": "8 - Practice 5 - (open_MCQ5)",
         "messages": [
+          "{{almost_done}}",
           "{{drill_how_to_fact_5}}",
-          "{{drill_practice_caps}} 5: {{answer_the_question}}\n\n{{drill_how_to_practice_5}}",
-          "{{almost_done}}"
+          "{{drill_practice_caps}} 5: {{answer_the_question}}\n\n{{drill_how_to_practice_5}}"
         ],
         "correct_response": "e) {{paper_towel_or_air_dryer}}"
       },
@@ -227,9 +227,9 @@
       {
         "slug": "01 - Self assessment",
         "messages": [
-          "{{drill_self_assess_3}}",
+          "{{drill_self_assess_1}}",
           "{{drill_self_assess_2}} {{covid_4_title}}. \n\n{{likert_1_10_knowledge}}",
-          "{{drill_self_assess_1}}"
+          "{{drill_self_assess_3}}"
         ],
         "response_user_profile_key": "self_rating_4"
       },
@@ -244,32 +244,32 @@
       {
         "slug": "03 - Q2",
         "messages": [
-          "{{drill_practice_caps}} 2: {{hand_sani_practice_2}}",
-          "{{hand_sani_fact_1}}"
+          "{{hand_sani_fact_1}}",
+          "{{drill_practice_caps}} 2: {{hand_sani_practice_2}}"
         ],
         "correct_response": "c) {{alcohol_based_hand_sanitizer}}"
       },
       {
         "slug": "04 - Q3",
         "messages": [
-          "{{drill_practice_caps}} 3: {{hand_sani_practice_3}}\n",
-          "{{hand_sani_fact_2}}"
+          "{{hand_sani_fact_2}}",
+          "{{drill_practice_caps}} 3: {{hand_sani_practice_3}}\n"
         ],
         "correct_response": "b) {{at_least_sixty_percent}}"
       },
       {
         "slug": "05 - Q4",
         "messages": [
-          "{{drill_practice_caps}} 4: \n\n{{hand_sani_practice_4}}",
-          "{{hand_sani_fact_3}}"
+          "{{hand_sani_fact_3}}",
+          "{{drill_practice_caps}} 4: \n\n{{hand_sani_practice_4}}"
         ],
         "correct_response": "a) {{true}}"
       },
       {
         "slug": "06 - Q5",
         "messages": [
-          "{{drill_practice_caps}} 5: \n\n{{hand_sani_practice_5}}\n",
-          "{{hand_sani_fact_4}}"
+          "{{hand_sani_fact_4}}",
+          "{{drill_practice_caps}} 5: \n\n{{hand_sani_practice_5}}\n"
         ],
         "correct_response": "d) {{are_sixty_to_ninety_percent_alcohol_based}}"
       },
@@ -293,33 +293,33 @@
       {
         "slug": "01 - Self Assessment",
         "messages": [
-          "{{drill_self_assess_3}}",
+          "{{drill_self_assess_1}}",
           "{{drill_self_assess_2}} {{covid_5_title}}. \n\n{{likert_1_10_knowledge}}",
-          "{{drill_self_assess_1}}"
+          "{{drill_self_assess_3}}"
         ],
         "response_user_profile_key": "self_rating_5"
       },
       {
         "slug": "02 - Q1",
         "messages": [
-          "{{drill_practice_caps}} 1: \n\n{{disinfect_phone_practice_1}}",
-          "{{thank_you}}"
+          "{{thank_you}}",
+          "{{drill_practice_caps}} 1: \n\n{{disinfect_phone_practice_1}}"
         ],
         "correct_response": "a) {{hands}}"
       },
       {
         "slug": "03 - Q2",
         "messages": [
-          "{{drill_practice_caps}} 2: \n\n{{disinfect_phone_practice_2}}",
-          "{{disinfect_phone_fact_1}}"
+          "{{disinfect_phone_fact_1}}",
+          "{{drill_practice_caps}} 2: \n\n{{disinfect_phone_practice_2}}"
         ],
         "correct_response": "a) {{true}}"
       },
       {
         "slug": "04 - Q3",
         "messages": [
-          "{{drill_practice_caps}} 3: \n\n{{disinfect_phone_practice_3}}\n",
-          "{{disinfect_phone_fact_2}}"
+          "{{disinfect_phone_fact_2}}",
+          "{{drill_practice_caps}} 3: \n\n{{disinfect_phone_practice_3}}\n"
         ],
         "correct_response": "a) {{yes}}"
       },
@@ -334,8 +334,8 @@
       {
         "slug": "06 - Q5",
         "messages": [
-          "{{drill_practice_caps}} 5: \n\n{{disinfect_phone_practice_5}}",
-          "{{disinfect_phone_fact_4}}"
+          "{{disinfect_phone_fact_4}}",
+          "{{drill_practice_caps}} 5: \n\n{{disinfect_phone_practice_5}}"
         ],
         "correct_response": "d) {{all of the above}}"
       },
@@ -360,9 +360,9 @@
       {
         "slug": "2 - self assessment - #",
         "messages": [
-          "{{drill_self_assess_3}}\n",
+          "{{drill_self_assess_1}}",
           "{{drill_self_assess_2}} {{covid_6_title}}.\n\n{{likert_1_10_knowledge}}",
-          "{{drill_self_assess_1}}"
+          "{{drill_self_assess_3}}\n"
         ],
         "response_user_profile_key": "self_rating_6"
       },
@@ -377,33 +377,33 @@
       {
         "slug": "4 - Practice 2 (MCQ3)",
         "messages": [
-          "{{drill_practice_caps}} 2: {{drill_when_to_practice_2}}",
-          "{{drill_when_to_fact_1}}\n"
+          "{{drill_when_to_fact_1}}\n",
+          "{{drill_practice_caps}} 2: {{drill_when_to_practice_2}}"
         ],
         "correct_response": "c) {{never}}"
       },
       {
         "slug": "5 - Practice 3 (FIB_MCQ3)",
         "messages": [
-          "{{drill_practice_caps}} 3:\n\n{{drill_when_to_practice_3}}",
-          "{{drill_when_to_fact_2}}"
+          "{{drill_when_to_fact_2}}",
+          "{{drill_practice_caps}} 3:\n\n{{drill_when_to_practice_3}}"
         ],
         "correct_response": "e) {{all_of_the_above}}"
       },
       {
         "slug": "6 - Practice 4 (FIB_MCQ5)",
         "messages": [
+          "{{drill_when_to_fact_3}}",
           "",
-          "{{drill_practice_caps}} 4: {{drill_when_to_practice_4}}",
-          "{{drill_when_to_fact_3}}"
+          "{{drill_practice_caps}} 4: {{drill_when_to_practice_4}}"
         ],
         "correct_response": "a) {{he_coughed_into_them}}"
       },
       {
         "slug": "7 - Practice 5",
         "messages": [
-          "{{drill_practice_caps}} 5: {{drill_when_to_practice_5}}\n",
-          "{{drill_when_to_fact_4}}\n"
+          "{{drill_when_to_fact_4}}\n",
+          "{{drill_practice_caps}} 5: {{drill_when_to_practice_5}}\n"
         ],
         "correct_response": "c) {{wash_her_hands_before_and_after}}"
       },
@@ -432,49 +432,49 @@
       {
         "slug": "01 - Self assessment",
         "messages": [
-          "{{drill_self_assess_3}}",
+          "{{drill_self_assess_1}}",
           "{{drill_self_assess_2}}{{covid_7_title}}. \n\n{{likert_1_10_knowledge}}",
-          "{{drill_self_assess_1}}"
+          "{{drill_self_assess_3}}"
         ],
         "response_user_profile_key": "self_rating_7"
       },
       {
         "slug": "02 - Q1",
         "messages": [
-          "{{drill_practice_caps}} 1: {{answer_the_question}}\n\n{{high_contact_practice_1}}\n",
-          "{{thank_you}}"
+          "{{thank_you}}",
+          "{{drill_practice_caps}} 1: {{answer_the_question}}\n\n{{high_contact_practice_1}}\n"
         ],
         "correct_response": "b) {{false}}"
       },
       {
         "slug": "03 - Q2",
         "messages": [
-          "{{drill_practice_caps}} 2: {{high_contact_practice_2}}",
-          "{{high_contact_fact_1}}"
+          "{{high_contact_fact_1}}",
+          "{{drill_practice_caps}} 2: {{high_contact_practice_2}}"
         ],
         "correct_response": "b) {{high_contact_surfaces}}"
       },
       {
         "slug": "04 - Q3",
         "messages": [
-          "{{drill_practice_caps}} 3: {{high_contact_practice_3}}\n",
-          "{{high_contact_fact_2}}"
+          "{{high_contact_fact_2}}",
+          "{{drill_practice_caps}} 3: {{high_contact_practice_3}}\n"
         ],
         "correct_response": "a) {{up_to_twenty_four_hours}}"
       },
       {
         "slug": "05 - Q4",
         "messages": [
-          "{{drill_practice_caps}} 4:\n\n{{high_contact_practice_4}}",
-          "{{high_contact_fact_3}}"
+          "{{high_contact_fact_3}}",
+          "{{drill_practice_caps}} 4:\n\n{{high_contact_practice_4}}"
         ],
         "correct_response": "b) {{two_to_three_days}}"
       },
       {
         "slug": "06 - Q5",
         "messages": [
-          "{{drill_practice_caps}} 5:\n\n{{high_contact_practice_5}}",
-          "{{high_contact_fact_4}}"
+          "{{high_contact_fact_4}}",
+          "{{drill_practice_caps}} 5:\n\n{{high_contact_practice_5}}"
         ],
         "correct_response": "a) {{clean_and_disinfect}}"
       },

--- a/stopcovid/drills/drill_content/translations.json
+++ b/stopcovid/drills/drill_content/translations.json
@@ -1,24133 +1,3674 @@
 {
   "instructions": [
     {
-      "id": 1665,
-      "label": "after",
-      "translation": "after",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1666,
-      "label": "all",
-      "translation": "all",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1669,
       "label": "answer_the_question",
       "translation": "Answer the question.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1670,
-      "label": "answer_the_question_about_the_photo",
-      "translation": "Answer the question about the photo.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1672,
-      "label": "anytime",
-      "translation": "anytime",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1673,
-      "label": "bad",
-      "translation": "bad",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1674,
-      "label": "before",
-      "translation": "before",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1675,
-      "label": "beforehand",
-      "translation": "beforehand",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1676,
-      "label": "benefits",
-      "translation": "benefits",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1677,
-      "label": "better",
-      "translation": "better",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1678,
-      "label": "boil",
-      "translation": "boil",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1679,
-      "label": "box",
-      "translation": "box",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1680,
-      "label": "bread",
-      "translation": "bread",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1681,
-      "label": "can",
-      "translation": "can",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1682,
-      "label": "cheese",
-      "translation": "cheese",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1684,
-      "label": "cough",
-      "translation": "cough",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1685,
-      "label": "cover",
-      "translation": "cover",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1686,
-      "label": "crab",
-      "translation": "crab",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1687,
-      "label": "cross_contamination",
-      "translation": "cross-contamination",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1688,
-      "label": "cut",
-      "translation": "cut",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1689,
-      "label": "cut_glove",
-      "translation": "cut glove",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1690,
-      "label": "dice",
-      "translation": "dice",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1691,
-      "label": "different",
-      "translation": "different",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1692,
-      "label": "direct_deposit",
-      "translation": "direct deposit",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1693,
-      "label": "employee",
-      "translation": "employee",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1694,
-      "label": "everyday",
-      "translation": "everyday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1697,
-      "label": "flat",
-      "translation": "flat",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1698,
-      "label": "fruit",
-      "translation": "fruit",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1699,
-      "label": "fry",
-      "translation": "fry",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1702,
-      "label": "grate",
-      "translation": "grate",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1703,
-      "label": "grill",
-      "translation": "grill",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1704,
-      "label": "hands",
-      "translation": "hands",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1705,
-      "label": "health_insurance",
-      "translation": "health insurance",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1706,
-      "label": "heavy",
-      "translation": "heavy",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1707,
-      "label": "inspection",
-      "translation": "inspection",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1711,
-      "label": "ladder",
-      "translation": "ladder",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1714,
-      "label": "lid",
-      "translation": "lid",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1715,
-      "label": "light",
-      "translation": "light",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1720,
-      "label": "now",
-      "translation": "now",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1721,
-      "label": "ok",
-      "translation": "ok",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1724,
-      "label": "oyster",
-      "translation": "oyster",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1725,
-      "label": "pan",
-      "translation": "pan",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1726,
-      "label": "peel",
-      "translation": "peel",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1727,
-      "label": "pot",
-      "translation": "pot",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1730,
-      "label": "recall",
-      "translation": "recall",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1731,
-      "label": "rice",
-      "translation": "rice",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1732,
-      "label": "right_now",
-      "translation": "right now",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1733,
-      "label": "safe_temperatures",
-      "translation": "safe temperatures",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1734,
-      "label": "same",
-      "translation": "same",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1735,
-      "label": "sanitary",
-      "translation": "sanitary",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1736,
-      "label": "saturday",
-      "translation": "Saturday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1737,
-      "label": "saute",
-      "translation": "saute",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1738,
-      "label": "shellfish",
-      "translation": "shellfish",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1739,
-      "label": "shrimp",
-      "translation": "shrimp",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1740,
-      "label": "simmer",
-      "translation": "simmer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1741,
-      "label": "sink",
-      "translation": "sink",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1742,
-      "label": "slice",
-      "translation": "slice",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1743,
-      "label": "smoke_break",
-      "translation": "smoke break",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1744,
-      "label": "sneeze",
-      "translation": "sneeze",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1745,
-      "label": "soap",
-      "translation": "soap",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1746,
-      "label": "spot",
-      "translation": "spot",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1667,
       "label": "almost_done",
       "translation": "Almost done! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1696,
-      "label": "final_practice",
-      "translation": "Final practice! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1708,
-      "label": "is_the_phrase_below_correct",
-      "translation": "🤔Is the phrase below correct?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1695,
-      "label": "fill_in_the_phrase_with_the_correct_word",
-      "translation": "👽Fill in the phrase with the correct word.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1710,
-      "label": "keep_going_one_more_practice",
-      "translation": "Keep going! One more practice! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1712,
-      "label": "last_practice",
-      "translation": "Last practice! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1717,
-      "label": "listen_to_the_audio_then_answer_the_question",
-      "translation": "🔊Listen to the audio. Then, answer the question.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1719,
-      "label": "listen_to_the_audio_then_fill_in_the_phrase_with_the_correct_word",
-      "translation": "🔊👽Listen to the audio. Then, fill in the phrase with the correct word.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1718,
-      "label": "listen_to_the_audio_then_fill_in_the_phrases_with_the_correct_words",
-      "translation": "🔊👽Listen to the audio. Then, fill in the phrases with the correct words.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1723,
-      "label": "listen_to_the_audio_write_the_words_in_the_correct_order",
-      "translation": "🔊🔀Listen to the audio. Write the words in the correct order.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1722,
-      "label": "one_more_practice",
-      "translation": "One more practice! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1728,
-      "label": "practice_speaking",
-      "translation": "🗣Practice speaking!",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1729,
-      "label": "practice_speaking_say_the_phrase_below",
-      "translation": "🗣Practice speaking! Say the phrase below.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1700,
-      "label": "you_are_close_to_the_end",
-      "translation": "You're close to the end! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1747,
-      "label": "staff",
-      "translation": "staff",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1748,
-      "label": "stand",
-      "translation": "stand",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1749,
-      "label": "stove",
-      "translation": "stove",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1750,
-      "label": "sunday",
-      "translation": "Sunday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1751,
-      "label": "take_out_container",
-      "translation": "take out container",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1752,
-      "label": "thermometer",
-      "translation": "thermometer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1755,
-      "label": "today",
-      "translation": "today",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1756,
-      "label": "today_lesson_is",
-      "translation": "Today's lesson is",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1757,
-      "label": "tomorrow",
-      "translation": "tomorrow",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1758,
-      "label": "towel",
-      "translation": "towel",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1760,
-      "label": "trash",
-      "translation": "trash",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1761,
-      "label": "tuna",
-      "translation": "tuna",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1762,
-      "label": "vacation_days",
-      "translation": "vacation days",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1763,
-      "label": "wash",
-      "translation": "wash",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1764,
-      "label": "water",
-      "translation": "water",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1765,
-      "label": "weekend",
-      "translation": "weekend",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1776,
-      "label": "yesterday",
-      "translation": "yesterday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1777,
-      "label": "your_word_of_the_day_is",
-      "translation": "Your word of the day is",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1779,
       "label": "audio_instructions_full_wa",
       "translation": "🎤 *Use WhatsApp to send your audio!* 🎤\n\n1. Press and hold the microphone ↘️\n2. Start talking.\n3. When finished, remove your finger from the microphone.\n4. Your voice will be sent automatically.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1781,
       "label": "audio_instructions_wa",
       "translation": "🎤 *Use WhatsApp to send your audio!* 🎤",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1782,
       "label": "audio_practice",
       "translation": "🎉 Your Practice!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1783,
       "label": "bye",
       "translation": "Have a good day! ☀️",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1784,
       "label": "celebration1",
       "translation": "{{emojis}} You successfully completed today's lesson {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1785,
       "label": "celebration10",
       "translation": "{{emojis}} Lesson complete! Amazing work. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1786,
       "label": "celebration11",
       "translation": "{{emojis}} Your lesson is done! See you next time, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1787,
       "label": "celebration12",
       "translation": "{{emojis}} What a great job. You finished today's lesson! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1788,
       "label": "celebration13",
       "translation": "{{emojis}} Lesson accomplished!!! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1789,
       "label": "celebration14",
       "translation": "{{emojis}} Lesson complete! Your English is getting better everyday! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1790,
       "label": "celebration15",
       "translation": "{{emojis}} Yeehaw!!! Your lesson is complete! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1791,
       "label": "celebration2",
       "translation": "{{emojis}} Excellent work today, {{name}}. Keep it up! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1792,
       "label": "celebration3",
       "translation": "{{emojis}} You did a great job today, {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1793,
       "label": "celebration4",
       "translation": "{{emojis}} Wow! Impressive effort today, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1794,
       "label": "celebration5",
       "translation": "{{emojis}} Today's lesson is done. Outstanding! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1795,
       "label": "celebration6",
       "translation": "{{emojis}} Woohoo! You finished today's lesson. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1796,
       "label": "celebration7",
       "translation": "{{emojis}} Your lesson is complete. Terrific job, {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1797,
       "label": "celebration8",
       "translation": "{{emojis}} Wonderful job, {{name}}! What a great lesson. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1798,
       "label": "celebration9",
       "translation": "{{emojis}} I'm proud of your work today. Thank you for your effort, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1799,
       "label": "correct_audio",
       "translation": "Here is my pronunciation compare it with yours.\n\n🎤 Try again or text me the word *DONE* to finish.\n",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1800,
       "label": "corrected_answer",
       "translation": "🤖 The correct answer is *{{correct_answer}}*.\n\nLets move to the next one.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1801,
       "label": "dropoff_ping",
       "translation": "👩🏻‍🏫 Hi {{student}}. You haven't completed a lesson in awhile. Are you still there?",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1802,
       "label": "dropoff_ping_v2",
       "translation": "Hi {{student}}. Your manager {{manager}} requested that I check in with you. How are your English lessons going?",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1803,
       "label": "employer",
       "translation": "your work",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1804,
       "label": "getting_gabby",
       "translation": "Please wait while I get 👩🏻‍🏫 Gabby.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1805,
       "label": "grade_soon",
       "translation": "🤖 I got your response. Your teacher will get back to you soon!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1806,
       "label": "hi",
       "translation": "Hi 👋",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1807,
       "label": "incorrect_answer",
       "translation": "🤖 Sorry, not correct. 🤔\n\n*Try again one more time!*",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1769,
-      "label": "what_do_you_hear_in_the_audio",
-      "translation": "🔊What do you hear in the audio?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-24T22:15:48Z",
-      "language": "en"
-    },
-    {
-      "id": 1768,
-      "label": "what_do_you_see_in_the_photo",
-      "translation": "⚡️What do you see in the photo?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1770,
-      "label": "what_does_this_word_mean",
-      "translation": "🤓What does this word mean?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1771,
-      "label": "what_word_rhymes_with",
-      "translation": "🤓What word rhymes with",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1773,
-      "label": "write_the_words_below_in_the_correct_order",
-      "translation": "🔀Write the words below in the correct order.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1780,
       "label": "audio_instructions_sms",
       "translation": "Call +19293352215",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1753,
-      "label": "lets_practice_write_the_words",
-      "translation": "Let's practice! Write the words",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1808,
       "label": "lesson_requires_text",
       "translation": "This practice is written. Please send me your answer by text.\n",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1778,
       "label": "audio_instructions_full_sms",
       "translation": "1. Call *+19293352215*\n2. Listen to the instructions\n3. Press 1\n4. Complete your speaking practice\n5. Hang up the phone when you are finished",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1810,
       "label": "lets_move_on",
       "translation": "Ok 👍 Let's continue...",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1812,
       "label": "more_next_shift",
       "translation": "👉🏼 More words {{day}}!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1813,
       "label": "nano_celebration",
       "translation": "{{audio_word}}! 👍",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1815,
       "label": "ok_thanks",
       "translation": "🤖 OK, thanks. 👍",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1816,
       "label": "pick_an_option",
       "translation": "Please text me a number between 1 and 5.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1817,
       "label": "practice_again",
       "translation": "Ok! Try your practice again.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1818,
       "label": "ready",
       "translation": "ready",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1819,
       "label": "ready_for_audio",
       "translation": "🤖 Hi {{student}}! Thanks for completing your speaking practice. Would you like to hear the audio that you recorded?\na. yes\nb. no",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1820,
       "label": "ready_for_lesson",
       "translation": "🤖 Hi {{student}}. Your next lesson is: *{{lesson_label}}*. Are you ready for it? a) yes b) no",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1821,
       "label": "ready_for_wotd",
       "translation": "Hi {{student}}. Your word of the day is *{{lesson_label}}*. Text 'YES' to listen to the audio.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1822,
       "label": "reminder_msg",
       "translation": "👩🏻‍🏫 You completed {{completed_activities}} out of {{total_activities}} activities in this lesson.\n\nText me the word *DONE* if you are done for today.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1823,
       "label": "reschedule",
       "translation": "Ok! 🗓️ I'm scheduling your lesson for {{day}}.\n\nIf you want to do it sooner, text me the word *READY*.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1826,
       "label": "till_tomorrow",
       "translation": "🤖 *Good Job! More lessons {{day}}* 🎉⭐️⭐️⭐️",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1827,
       "label": "transfer1",
       "translation": "*Homework:* Now, go back to work and practice today's words.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1828,
       "label": "transfer10",
       "translation": "*Homework:* Ok! Now, be brave and go speak English with your manager.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1829,
       "label": "transfer11",
       "translation": "*Homework:* Go practice speaking! Write down the words you learned on your schedule.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1830,
       "label": "transfer12",
       "translation": "*Homework:* Did you tell your manager that you finished your lesson? Go tell them what you learned today!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1831,
       "label": "transfer13",
       "translation": "*Homework:* Now, talk with a friend at work about your lesson.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1832,
       "label": "transfer14",
       "translation": "*Homework:* Here is a tip to help you with your speaking. Spell the words you learned today out loud with your voice.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1833,
       "label": "transfer15",
       "translation": "*Homework:* Be brave and go practice speaking! Write down the words you learned today on your prep list.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1834,
       "label": "transfer2",
       "translation": "*Homework:* Ok. Try to practice your word 3 times with a friend today.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1835,
       "label": "transfer3",
       "translation": "*Homework:* Now, practice at your job. Talk to your manager about what you learned today!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1836,
       "label": "transfer4",
       "translation": "*Homework:* While you are at work today, listen for the words you just learned.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1837,
       "label": "transfer5",
       "translation": "*Homework:* For more practice, say the words you learned in the mirror 3 times.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1838,
       "label": "transfer6",
       "translation": "*Homework:* Ok! Now practice with a coworker to keep improving.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1839,
       "label": "transfer7",
       "translation": "*Homework*: Go talk with a coworker. Use the words you learned today.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1840,
       "label": "transfer8",
       "translation": "*Homework*: Write your new words on a piece of tape. Put the tape in your locker and practice every shift!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1841,
       "label": "transfer9",
       "translation": "*Homework*: Listen to the audio file you made 3 times today!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1842,
       "label": "try_again_done",
       "translation": "🎤 Try again or text me the word *DONE* to finish.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1843,
       "label": "try_again_next",
       "translation": "🎤 Try again or text me the word *NEXT* to listen to my pronunciation.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1844,
       "label": "wotd_corrected_answer",
       "translation": "🤖 The correct answer is *{{correct_answer}}*.\n\nText *MORE* to get another",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1845,
       "label": "wotd_more_correct_answer",
       "translation": "🤖 {{happy_word}}! You are correct!\n{{emojis}}\nText *MORE* to get another",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1846,
       "label": "wotd_tomorrow_correct_answer",
       "translation": "🤖 {{happy_word}}! You are correct!\n{{emojis}}\nMore words {{day}}!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1847,
       "label": "you_are_welcome",
       "translation": "You're welcome 😊",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1848,
-      "label": "after",
-      "translation": "después",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1849,
-      "label": "all",
-      "translation": "todos",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1852,
       "label": "answer_the_question",
       "translation": "Responde la pregunta.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1853,
-      "label": "answer_the_question_about_the_photo",
-      "translation": "Responde la pregunta sobre la foto.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1855,
-      "label": "anytime",
-      "translation": "en cualquier momento",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1856,
-      "label": "bad",
-      "translation": "mal",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1857,
-      "label": "before",
-      "translation": "antes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1858,
-      "label": "beforehand",
-      "translation": "de antemano",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1859,
-      "label": "benefits",
-      "translation": "beneficios",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1860,
-      "label": "better",
-      "translation": "mejor",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1861,
-      "label": "boil",
-      "translation": "hervir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1862,
-      "label": "box",
-      "translation": "caja",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1863,
-      "label": "bread",
-      "translation": "pan",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1864,
-      "label": "can",
-      "translation": "lata",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1865,
-      "label": "cheese",
-      "translation": "queso",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1867,
-      "label": "cough",
-      "translation": "toser",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1809,
       "label": "lesson_requires_voice",
       "translation": "{{audio_instructions}}",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1850,
       "label": "almost_done",
       "translation": "¡Casi terminas! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1814,
       "label": "need_something",
       "translation": "We got your message. Thank you!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1811,
       "label": "match_correct_answer",
       "translation": "🤖 Correct! {{emojis}}",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 1868,
-      "label": "cover",
-      "translation": "cubrir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1869,
-      "label": "crab",
-      "translation": "cangrejo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1870,
-      "label": "cross_contamination",
-      "translation": "contaminación cruzada",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1871,
-      "label": "cut",
-      "translation": "cortar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1872,
-      "label": "cut_glove",
-      "translation": "guante para cortar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1873,
-      "label": "dice",
-      "translation": "picar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1874,
-      "label": "different",
-      "translation": "diferente",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1875,
-      "label": "direct_deposit",
-      "translation": "deposito directo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1876,
-      "label": "employee",
-      "translation": "empleado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1877,
-      "label": "everyday",
-      "translation": "todos los días",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1880,
-      "label": "flat",
-      "translation": "plano",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1881,
-      "label": "fruit",
-      "translation": "fruta",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1882,
-      "label": "fry",
-      "translation": "freir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1885,
-      "label": "grate",
-      "translation": "rallar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1886,
-      "label": "grill",
-      "translation": "asar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1888,
-      "label": "health_insurance",
-      "translation": "seguro de salud",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1889,
-      "label": "heavy",
-      "translation": "pesado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1890,
-      "label": "inspection",
-      "translation": "inspección",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1894,
-      "label": "ladder",
-      "translation": "escalera",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1897,
-      "label": "lid",
-      "translation": "tapa",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1898,
-      "label": "light",
-      "translation": "ligero",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1903,
-      "label": "now",
-      "translation": "ahora",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1904,
-      "label": "ok",
-      "translation": "ok",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1907,
-      "label": "oyster",
-      "translation": "ostra",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1908,
-      "label": "pan",
-      "translation": "sartén",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1909,
-      "label": "peel",
-      "translation": "pelar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1910,
-      "label": "pot",
-      "translation": "olla",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1913,
-      "label": "recall",
-      "translation": "retiro",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1914,
-      "label": "rice",
-      "translation": "arroz",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1915,
-      "label": "right_now",
-      "translation": "ahora mismo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1916,
-      "label": "safe_temperatures",
-      "translation": "temperaturas seguras",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1917,
-      "label": "same",
-      "translation": "igual",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1918,
-      "label": "sanitary",
-      "translation": "sanitario",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1919,
-      "label": "saturday",
-      "translation": "sabado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1920,
-      "label": "saute",
-      "translation": "saltear",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1921,
-      "label": "shellfish",
-      "translation": "mariscos",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1922,
-      "label": "shrimp",
-      "translation": "camarones",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1923,
-      "label": "simmer",
-      "translation": "hervir a fuego lento",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1924,
-      "label": "sink",
-      "translation": "lavabo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1925,
-      "label": "slice",
-      "translation": "rebanar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1926,
-      "label": "smoke_break",
-      "translation": "receso para fumar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1927,
-      "label": "sneeze",
-      "translation": "estornudar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1928,
-      "label": "soap",
-      "translation": "jabón",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1929,
-      "label": "spot",
-      "translation": "sostener",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1930,
-      "label": "staff",
-      "translation": "personal",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1931,
-      "label": "stand",
-      "translation": "pararse",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1932,
-      "label": "stove",
-      "translation": "estufa",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1933,
-      "label": "sunday",
-      "translation": "domingo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1934,
-      "label": "take_out_container",
-      "translation": "contenedor para llevar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1935,
-      "label": "thermometer",
-      "translation": "termómetro",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1938,
-      "label": "today",
-      "translation": "hoy",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1939,
-      "label": "today_lesson_is",
-      "translation": "La lección de hoy es",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1940,
-      "label": "tomorrow",
-      "translation": "mañana",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1943,
-      "label": "trash",
-      "translation": "basura",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1944,
-      "label": "tuna",
-      "translation": "atún",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1945,
-      "label": "vacation_days",
-      "translation": "días de vacaciones",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1946,
-      "label": "wash",
-      "translation": "lavar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1947,
-      "label": "water",
-      "translation": "agua",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1879,
-      "label": "final_practice",
-      "translation": "¡Práctica final! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1891,
-      "label": "is_the_phrase_below_correct",
-      "translation": "🤔¿Es correcta la siguiente frase?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1893,
-      "label": "keep_going_one_more_practice",
-      "translation": "¡Sigue adelante! ¡Una práctica más! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1895,
-      "label": "last_practice",
-      "translation": "¡Última práctica! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1900,
-      "label": "listen_to_the_audio_then_answer_the_question",
-      "translation": "🔊Escucha el audio. Luego, responda la pregunta.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1902,
-      "label": "listen_to_the_audio_then_fill_in_the_phrase_with_the_correct_word",
-      "translation": "🔊👽Escucha el audio. Luego, rellena la frase con la palabra correcta.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1901,
-      "label": "listen_to_the_audio_then_fill_in_the_phrases_with_the_correct_words",
-      "translation": "🔊👽Escucha el audio. Luego, rellena las frases con las palabras correctas.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1906,
-      "label": "listen_to_the_audio_write_the_words_in_the_correct_order",
-      "translation": "🔊🔀Escucha el audio. Escribe las palabras en el orden correcto.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1905,
-      "label": "one_more_practice",
-      "translation": "¡Una práctica más! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1911,
-      "label": "practice_speaking",
-      "translation": "🗣¡Practica hablar!",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1912,
-      "label": "practice_speaking_say_the_phrase_below",
-      "translation": "🗣¡Practica hablar! Di la siguiente frase.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1883,
-      "label": "you_are_close_to_the_end",
-      "translation": "¡Estás cerca del final! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1936,
-      "label": "lets_practice_write_the_words",
-      "translation": "Practiquemos! Escribe las palabras",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1887,
-      "label": "hands",
-      "translation": "los manos",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-03-23T20:52:46Z",
-      "language": "es"
-    },
-    {
-      "id": 1948,
-      "label": "weekend",
-      "translation": "fin de semana",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1959,
-      "label": "yesterday",
-      "translation": "ayer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1960,
-      "label": "your_word_of_the_day_is",
-      "translation": "Tu palabra del día es",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1962,
       "label": "audio_instructions_full_wa",
       "translation": "\n🎤 *Usa WhatsApp para enviar tu mensaje de voz!* 🎤\n\n1. Mantén presionado el micrófono ↘\n2. Comienza a hablar.\n3. Cuando termines, retira tu dedo del micrófono.\n4. Tu voz se enviará automáticamente.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1964,
       "label": "audio_instructions_wa",
       "translation": "🎤 *Usa WhatsApp para enviar tu mensaje de voz!* 🎤",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1965,
       "label": "audio_practice",
       "translation": "🎉 ¡Su práctica!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1966,
       "label": "bye",
       "translation": "¡Ten un buen día! ☀️",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2599,
-      "label": "ask_for",
-      "translation": "ask for",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2600,
-      "label": "appear",
-      "translation": "appear",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 1952,
-      "label": "what_do_you_hear_in_the_audio",
-      "translation": "🔊¿Qué escuchas en el audio?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-24T22:15:16Z",
-      "language": "es"
-    },
-    {
-      "id": 1956,
-      "label": "write_the_words_below_in_the_correct_order",
-      "translation": "🔀Escribe las siguientes palabras en el orden correcto.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1951,
-      "label": "what_do_you_see_in_the_photo",
-      "translation": "⚡️¿Qué ves en la foto?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1953,
-      "label": "what_does_this_word_mean",
-      "translation": "🤓¿Qué significa la palabra?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 1954,
-      "label": "what_word_rhymes_with",
-      "translation": "🤓¿Qué palabra rima con",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-24T00:53:15Z",
-      "language": "es"
-    },
-    {
-      "id": 1963,
       "label": "audio_instructions_sms",
       "translation": "Llama al +19293352215",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1982,
       "label": "correct_audio",
       "translation": "Aquí está mi pronunciación comparala con la tuya.\n\n🎤 Puedes intentar nuevamente o enviarme la palabra *DONE* para terminar.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1983,
       "label": "corrected_answer",
       "translation": "🤖 La respuesta correcta es *{{correct_answer}}*.\n\nAvancemos a la siguiente.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1984,
       "label": "dropoff_ping",
       "translation": "🤖 Hola {{student}}. Hace tiempo que no ha completado una lección. ¿Está todavía allí?",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1985,
       "label": "dropoff_ping_v2",
       "translation": "Hola, {{student}}. Su gerente {{manager}} me pidió que me hablara con usted. ¿Cómo van tus lecciones de inglés?",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1986,
       "label": "employer",
       "translation": "tu trabajo",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1987,
       "label": "getting_gabby",
       "translation": "Por favor, espera mientras consigo a 👩🏻‍🏫 Gabby.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1988,
       "label": "grade_soon",
       "translation": "🤖 Recibí tu respuesta. ¡Tu profesor te responderá pronto!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1989,
       "label": "hi",
       "translation": "Hola 👋",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1990,
       "label": "incorrect_answer",
       "translation": "🤖 Lo siento, no es correcto.🤔\n\n*¡Intenta una vez más!*",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1993,
       "label": "lets_move_on",
       "translation": "Ok 👍 Continuemos...",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1961,
       "label": "audio_instructions_full_sms",
       "translation": "1. Llama al *+19293352215*\n2. Escucha las instrucciones\n3. Presiona 1\n4. Completa tu práctica de hablar\n5. Cuelga el teléfono cuando termines.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1995,
       "label": "more_next_shift",
       "translation": "👉🏼 Más palabras {{day}}!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1998,
       "label": "ok_thanks",
       "translation": "🤖 OK, gracias. 👍",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1999,
       "label": "pick_an_option",
       "translation": "Por favor envíame un número entre 1 y 5.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2000,
       "label": "practice_again",
       "translation": "Ok! Inténta tu practica otra vez.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2001,
       "label": "ready",
       "translation": "muy especial",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2002,
       "label": "ready_for_audio",
       "translation": "🤖 ¡Hola, {{student}}! Gracias por completar su práctica de hablar. ¿Le gustaría escuchar el audio que grabó?\na. sí\nb. no",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2003,
       "label": "ready_for_lesson",
       "translation": "🤖 Hola {{student}}. Tu próxima lección es: *{{lesson_label}}*. ¿Estás listo para hacerlo? a) sí b) no",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2004,
       "label": "ready_for_wotd",
       "translation": "Hola {{student}}. Tu palabra del día es *{{lesson_label}}*. Escriba \"SÍ\" para escuchar el audio.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2005,
       "label": "reminder_msg",
       "translation": "👩🏻‍🏫 Has completado {{completed_activities}} de {{total_activities}} actividades en esta lección.\n\nEnvíame la palabra *DONE* si has terminado por hoy.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2006,
       "label": "reschedule",
       "translation": "¡Ok! 🗓️ Estoy programando tu lección para el {{day}}.\n\nSi quieres hacerlo antes, envíame la palabra *READY*.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1969,
       "label": "celebration11",
       "translation": "{{emojis}} Your lesson is done! See you next time, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1971,
       "label": "celebration13",
       "translation": "{{emojis}} Lesson accomplished!!! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1972,
       "label": "celebration14",
       "translation": "{{emojis}} Lesson complete! Your English is getting better everyday! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2157,
       "label": "celebration2",
       "translation": "{{emojis}} Excellent work today, {{name}}. Keep it up! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 1975,
       "label": "celebration3",
       "translation": "{{emojis}} You did a great job today, {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1977,
       "label": "celebration5",
       "translation": "{{emojis}} Today's lesson is done. Outstanding! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1979,
       "label": "celebration7",
       "translation": "{{emojis}} Your lesson is complete. Terrific job, {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1981,
       "label": "celebration9",
       "translation": "{{emojis}} I'm proud of your work today. Thank you for your effort, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1996,
       "label": "nano_celebration",
       "translation": "{{audio_word}}! 👍",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1991,
       "label": "lesson_requires_text",
       "translation": "Esta práctica es escrita. Por favor, escribe tu respuesta.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1992,
       "label": "lesson_requires_voice",
       "translation": "{{audio_instructions}}",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1997,
       "label": "need_something",
       "translation": "Recibimos tu mensaje. ¡Gracias!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2009,
       "label": "till_tomorrow",
       "translation": "🤖 *Buen Trabajo! Más lecciones {{day}}* 🎉⭐️⭐️⭐️",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2602,
-      "label": "listen",
-      "translation": "listen",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2033,
       "label": "almost_done",
       "translation": "C'est presque terminé ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2062,
-      "label": "final_practice",
-      "translation": "Dernier exercice! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2074,
-      "label": "is_the_phrase_below_correct",
-      "translation": "🤔La phrase ci-dessous est-elle correcte?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2061,
-      "label": "fill_in_the_phrase_with_the_correct_word",
-      "translation": "👽Complétez la phrase avec le mot juste.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2076,
-      "label": "keep_going_one_more_practice",
-      "translation": "Continuez! Plus qu'un exercice! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2078,
-      "label": "last_practice",
-      "translation": "Dernier exercice! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2083,
-      "label": "listen_to_the_audio_then_answer_the_question",
-      "translation": "🔊Écoutez l'enregistrement puis répondez à la question.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2025,
       "label": "try_again_done",
       "translation": "🎤 Puedes intentar nuevamente o enviarme la palabra *DONE* para terminar.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2026,
       "label": "try_again_next",
       "translation": "🎤 Puedes intentar nuevamente o enviarme la palabra *NEXT* para escuchar mi pronunciación.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2027,
       "label": "wotd_corrected_answer",
       "translation": "🤖 La respuesta correcta es *{{correct_answer}}*.\n\nEnviame *MORE* para recibir otra.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2028,
       "label": "wotd_more_correct_answer",
       "translation": "🤖 {{happy_word}}! You are correct!\n{{emojis}}\nEnviame *MORE* para recibir otra.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2029,
       "label": "wotd_tomorrow_correct_answer",
       "translation": "🤖 {{happy_word}}! You are correct!\n{{emojis}}\nMás palabras {{day}}!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2030,
       "label": "you_are_welcome",
       "translation": "De nada 😊",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2031,
-      "label": "after",
-      "translation": "après",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2032,
-      "label": "all",
-      "translation": "tous",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2035,
       "label": "answer_the_question",
       "translation": "Répondez à la question.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2036,
-      "label": "answer_the_question_about_the_photo",
-      "translation": "Répondez à la question à propos de la photo.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2038,
-      "label": "anytime",
-      "translation": "n'importe quand",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2039,
-      "label": "bad",
-      "translation": "mauvais",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2040,
-      "label": "before",
-      "translation": "avant",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2041,
-      "label": "beforehand",
-      "translation": "à l'avance",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2042,
-      "label": "benefits",
-      "translation": "bénéfices",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2043,
-      "label": "better",
-      "translation": "mieux",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2044,
-      "label": "boil",
-      "translation": "bouillir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2045,
-      "label": "box",
-      "translation": "boîte",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2046,
-      "label": "bread",
-      "translation": "pain",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2047,
-      "label": "can",
-      "translation": "conserve",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2048,
-      "label": "cheese",
-      "translation": "fromage",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2050,
-      "label": "cough",
-      "translation": "tousser",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2051,
-      "label": "cover",
-      "translation": "couvrir\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2052,
-      "label": "crab",
-      "translation": "crab",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2053,
-      "label": "cross_contamination",
-      "translation": "contamination croisée",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2054,
-      "label": "cut",
-      "translation": "couper",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2055,
-      "label": "cut_glove",
-      "translation": "gant anti-coupure\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2056,
-      "label": "dice",
-      "translation": "dés",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2057,
-      "label": "different",
-      "translation": "différent",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2058,
-      "label": "direct_deposit",
-      "translation": "virement automatique",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2059,
-      "label": "employee",
-      "translation": "employé",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2060,
-      "label": "everyday",
-      "translation": "chaque jour",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2063,
-      "label": "flat",
-      "translation": "plat\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2064,
-      "label": "fruit",
-      "translation": "fruit",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2065,
-      "label": "fry",
-      "translation": "faire frire\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2068,
-      "label": "grate",
-      "translation": "râper\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2069,
-      "label": "grill",
-      "translation": "faire griller\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2071,
-      "label": "health_insurance",
-      "translation": "assurance maladie",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2072,
-      "label": "heavy",
-      "translation": "lourd",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2073,
-      "label": "inspection",
-      "translation": "inspection",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2077,
-      "label": "ladder",
-      "translation": "échelle",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2080,
-      "label": "lid",
-      "translation": "couvercle",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2081,
-      "label": "light",
-      "translation": "lumière\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2066,
-      "label": "you_are_close_to_the_end",
-      "translation": "C'est bientôt fini! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2011,
       "label": "transfer10",
       "translation": "*Tarea*: Ok! Ahora, se valiente e intenta hablar un poco de inglés con tu gerente.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2014,
       "label": "transfer13",
       "translation": "*Tarea*: Ahora, habla con un amigo en el trabajo sobre tu lección. ¿Saben las palabras que aprendiste hoy?",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2016,
       "label": "transfer15",
       "translation": "*Tarea*: ¡Sea valiente y practica a hablar! Escriba las palabras que aprendió hoy en su lista de preparación u horario.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2018,
       "label": "transfer3",
       "translation": "*Tarea*: Ahora, practica en tu trabajo. ¡Hable con su gerente sobre lo que aprendió hoy!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2020,
       "label": "transfer5",
       "translation": "*Tarea*: Para más práctica, diga las palabras que aprendió en el espejo 3 veces.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2023,
       "label": "transfer8",
       "translation": "*Tarea*: ¡Aquí tienes un consejo! Escriba las nuevas palabras que aprendió en un trozo de papel, pegalo en tu casillero y ¡Practica cada vez que cambies tu uniforme!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2070,
-      "label": "hands",
-      "translation": "Les mains",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-03-23T20:52:35Z",
-      "language": "fr"
-    },
-    {
-      "id": 2086,
-      "label": "now",
-      "translation": "maintenant",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2087,
-      "label": "ok",
-      "translation": "ok",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2090,
-      "label": "oyster",
-      "translation": "huître",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2091,
-      "label": "pan",
-      "translation": "poêle",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2092,
-      "label": "peel",
-      "translation": "peler\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2093,
-      "label": "pot",
-      "translation": "marmite",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2096,
-      "label": "recall",
-      "translation": "se rappeler",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2097,
-      "label": "rice",
-      "translation": "riz",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2098,
-      "label": "right_now",
-      "translation": "tout de suite\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2099,
-      "label": "safe_temperatures",
-      "translation": "température de sécurité",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2100,
-      "label": "same",
-      "translation": "le\/la même",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2101,
-      "label": "sanitary",
-      "translation": "sanitaire",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2102,
-      "label": "saturday",
-      "translation": "samedi\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2103,
-      "label": "saute",
-      "translation": "sauté",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2104,
-      "label": "shellfish",
-      "translation": "fruit de mer\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2105,
-      "label": "shrimp",
-      "translation": "crevette",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2106,
-      "label": "simmer",
-      "translation": "faire mijoter\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2107,
-      "label": "sink",
-      "translation": "évier",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2108,
-      "label": "slice",
-      "translation": "tranche",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2109,
-      "label": "smoke_break",
-      "translation": "pause cigarette",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2110,
-      "label": "sneeze",
-      "translation": "éternuer\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2111,
-      "label": "soap",
-      "translation": "savon",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2112,
-      "label": "spot",
-      "translation": "tache",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2113,
-      "label": "staff",
-      "translation": "personnel\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2114,
-      "label": "stand",
-      "translation": "se tenir debout\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2115,
-      "label": "stove",
-      "translation": "cuisinière",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2116,
-      "label": "sunday",
-      "translation": "dimanche",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2117,
-      "label": "take_out_container",
-      "translation": "barquette",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2118,
-      "label": "thermometer",
-      "translation": "thermomètre",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2121,
-      "label": "today",
-      "translation": "aujourd'hui",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2122,
-      "label": "today_lesson_is",
-      "translation": "La leçon du jour est",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2123,
-      "label": "tomorrow",
-      "translation": "demain",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2126,
-      "label": "trash",
-      "translation": "déchet\n",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2127,
-      "label": "tuna",
-      "translation": "thon",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2128,
-      "label": "vacation_days",
-      "translation": "jours de congé",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2129,
-      "label": "wash",
-      "translation": "laver",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2130,
-      "label": "water",
-      "translation": "eau",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2131,
-      "label": "weekend",
-      "translation": "week-end",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2142,
-      "label": "yesterday",
-      "translation": "hier",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2143,
-      "label": "your_word_of_the_day_is",
-      "translation": "Votre mot du jour est",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2145,
       "label": "audio_instructions_full_wa",
       "translation": "🎤 *Utilisez WhatsApp pour envoyer votre audio !* 🎤\n\n1. Appuyer sur et maintenez la touche micro ↘️\n2. Parlez.\n3. Quand vous avez fini relâcher la touche micro.\n4. Votre enregistrement sera envoyé automatiquement.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2147,
       "label": "audio_instructions_wa",
       "translation": "🎤 *Utilisez WhatsApp pour envoyer votre audio!* 🎤",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2148,
       "label": "audio_practice",
       "translation": "🎉 Votre leçon!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2149,
       "label": "bye",
       "translation": "Passez une bonne journée! ☀️",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2603,
-      "label": "pay_attention",
-      "translation": "pay attention",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2085,
-      "label": "listen_to_the_audio_then_fill_in_the_phrase_with_the_correct_word",
-      "translation": "🔊👽Écoutez l'enregistrement puis complétez la phrase avec le mot juste.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2134,
-      "label": "what_do_you_see_in_the_photo",
-      "translation": "⚡️Que voyez-vous sur la photo?\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2084,
-      "label": "listen_to_the_audio_then_fill_in_the_phrases_with_the_correct_words",
-      "translation": "🔊👽Écoutez l'enregistrement puis complétez les phrases avec les mots justes.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2152,
       "label": "celebration11",
       "translation": "{{emojis}} Your lesson is done! See you next time, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2154,
       "label": "celebration13",
       "translation": "{{emojis}} Lesson accomplished!!! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2156,
       "label": "celebration15",
       "translation": "{{emojis}} Yeehaw!!! Your lesson is complete! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2089,
-      "label": "listen_to_the_audio_write_the_words_in_the_correct_order",
-      "translation": "🔊🔀Écoutez l'enregistrement puis écrivez les mots dans le bon ordre.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2088,
-      "label": "one_more_practice",
-      "translation": "Encore un exercice! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2094,
-      "label": "practice_speaking",
-      "translation": "🗣Entraînez-vous à l'orale!",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2095,
-      "label": "practice_speaking_say_the_phrase_below",
-      "translation": "🗣Entraînez-vous à l'orale! Dîtes les phrases ci-dessus.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2132,
-      "label": "what_do_you_hear_in_the_audio",
-      "translation": "🔊Qu'entendez-vous dans l'enregistrement?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2136,
-      "label": "what_does_this_word_mean",
-      "translation": "🤓Que veux dire ce mot?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2137,
-      "label": "what_word_rhymes_with",
-      "translation": "🤓Quel mot rime avec",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2139,
-      "label": "write_the_words_below_in_the_correct_order",
-      "translation": "🔀Écivez les mots ci-dessous dans le bon ordre.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2144,
       "label": "audio_instructions_full_sms",
       "translation": "1. Appelez le *+19293352215*\n2. Écouter les consignes\n3. Taper 1\n4. Compléter votre expression orale\n5. Raccrochez quand vous avez terminé",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2119,
-      "label": "lets_practice_write_the_words",
-      "translation": "Pratiquons! Écrivez le mots",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2146,
       "label": "audio_instructions_sms",
       "translation": "Appelez le +19293352215",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2604,
-      "label": "since",
-      "translation": "since",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2191,
       "label": "text_done",
       "translation": "Compris 👍 envoyez-moi *DONE* pour terminer.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2214,
-      "label": "practice_speaking_fill_in_the_sentence_then_send_me_audio",
-      "translation": "🗣Practice Speaking! Fill in the sentence. Then send me audio.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2165,
       "label": "correct_audio",
       "translation": "Voici ma prononciation, comparez-la à la vôtre.\n\n🎤 Réessayer ou envoyez le mot *DONE* pour terminer.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2166,
       "label": "corrected_answer",
       "translation": "🤖 La bonne réponse est *{{correct_answer}}*.\n\nPassons à la suite.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2167,
       "label": "dropoff_ping",
       "translation": "👩🏻‍🏫 Bonjour {{student}}! Il n'a pas terminé une leçon depuis un moment. Est-il toujours là?",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2168,
       "label": "dropoff_ping_v2",
       "translation": "Bonjour {{student}}. Votre responsable {{manager}} m'a demandé de vous parler. Comment se déroulent vos cours d'anglais?",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2169,
       "label": "employer",
       "translation": "votre travail",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2170,
       "label": "getting_gabby",
       "translation": "Patientez pendant que je contacte 👩🏻‍🏫 Gabby.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2171,
       "label": "grade_soon",
       "translation": "🤖 J'ai reçu votre réponse. Votre professeur vous répondra bientôt!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2172,
       "label": "hi",
       "translation": "Bonjour 👋",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2173,
       "label": "incorrect_answer",
       "translation": "🤖 Désolé, ce n'est pas correct. 🤔\n\n*Essayez à nouveau!*",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2176,
       "label": "lets_move_on",
       "translation": "Ok 👍 Continuons...",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2178,
       "label": "more_next_shift",
       "translation": "👉🏼 Plus de mots {{day}}!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2181,
       "label": "ok_thanks",
       "translation": "🤖 OK, merci. 👍",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2182,
       "label": "pick_an_option",
       "translation": "Veuillez saisir un numéro entre 1 et 5.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2183,
       "label": "practice_again",
       "translation": "Ok! Esaayez à nouveau.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2184,
       "label": "ready",
       "translation": "Prêt",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2185,
       "label": "ready_for_audio",
       "translation": "🤖 Bonjour, {{student}}! Merci d'avoir complété votre pratique de la parole. Voulez-vous écouter l'audio que vous avez enregistré?\na. oui\nb. non",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2186,
       "label": "ready_for_lesson",
       "translation": "🤖 Bonjour {{student}}. Votre prochain cours est le suivant: *{{lesson_label}}*. Êtes-vous prêt? a) oui b) non\n",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2187,
       "label": "ready_for_wotd",
       "translation": "Bonjour {{student}}. Votre mot du jour est *{{lesson_label}}*. Tapez \"OUI\" pour écouter l'audio.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2188,
       "label": "reminder_msg",
       "translation": "👩🏻‍🏫 Vous avez terminé {{completed_activities}} activités sur {{total_activities}} pour cette leçon.\n\nTapez le mot *DONE* si vous avez fini pour aujourd'hui.\n",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2189,
       "label": "reschedule",
       "translation": "Ok! 🗓️ Je programme votre leçon pour {{day}}\n\nSi vous voulez la faire avant, envoyez *READY*.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2192,
       "label": "till_tomorrow",
       "translation": "🤖 *Beau travail! Plus de leçons {{day}}* 🎉⭐️⭐️⭐️",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2215,
-      "label": "practice_speaking_fill_in_the_sentence_then_send_me_audio",
-      "translation": "🗣¡Practica Hablar! Rellena la frase. luego enviame audio.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2217,
-      "label": "practice_speaking_say_the_word_below",
-      "translation": "🗣¡Practica hablar! Di la siguiente palabra 3 veces.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-23T20:05:31Z",
-      "language": "es"
-    },
-    {
-      "id": 2175,
       "label": "lesson_requires_voice",
       "translation": "{{audio_instructions}}",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2174,
       "label": "lesson_requires_text",
       "translation": "Cet un exercice à l'écrit. Veuillez m'envoyer votre réponse par SMS.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2177,
       "label": "match_correct_answer",
       "translation": "🤖 C'est Correct! {{emojis}}",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2208,
       "label": "try_again_done",
       "translation": "Réessayez ou envoyez *DONE* pour terminer.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2209,
       "label": "try_again_next",
       "translation": "Réessayez ou envoyez *NEXT* pour écouter ma prononciation.\n",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2210,
       "label": "wotd_corrected_answer",
       "translation": "🤖 La bonne réponse est *{{correct_answer}}*.\n\nEnvoyez *MORE* pour un autre exercice.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2211,
       "label": "wotd_more_correct_answer",
       "translation": "🤖 {{happy_word}}! Bonne réponse!\n{{emojis}}\nEnvoyez *MORE* pour un autre exercice.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2212,
       "label": "wotd_tomorrow_correct_answer",
       "translation": "🤖 {{happy_word}}! Bonne réponse!\n{{emojis}}\nPlus de mots {{day}}!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2213,
       "label": "you_are_welcome",
       "translation": "Je vous en prie 😊",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 1967,
       "label": "celebration1",
       "translation": "{{emojis}} You successfully completed today's lesson {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2150,
       "label": "celebration1",
       "translation": "{{emojis}} You successfully completed today's lesson {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2151,
       "label": "celebration10",
       "translation": "{{emojis}} Lesson complete! Amazing work. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2161,
       "label": "celebration6",
       "translation": "{{emojis}} Woohoo! You finished today's lesson. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2163,
       "label": "celebration8",
       "translation": "{{emojis}} Wonderful job, {{name}}! What a great lesson. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2179,
       "label": "nano_celebration",
       "translation": "{{audio_word}}! 👍",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2194,
       "label": "transfer10",
       "translation": "*Les devoirs:* Ok! Maintenant, soyez courageux et essayer d'aller parler un peu anglais avec votre manager.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2197,
       "label": "transfer13",
       "translation": "*Les devoirs:* Maintenant, parlez de votre leçon avec un ami au travail. Connaissent-ils les mots que vous avez appris aujourd'hui?",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2200,
       "label": "transfer2",
       "translation": "*Les devoirs:* Ok. Essayez d'utiliser 3 fois votre mot avec un ami aujourd'hui.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2201,
       "label": "transfer3",
       "translation": "*Les devoirs:* Maintenant, entraînez-vous au travail. Parlez à votre manager de ce que vous avez appris aujourd'hui!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2203,
       "label": "transfer5",
       "translation": "*Les devoirs:* Pour plus de pratique, dites les mots que vous avez appris dans le miroir 3 fois.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2207,
       "label": "transfer9",
       "translation": "*Les devoirs:* Pour améliorer votre prononciation, il est bon de vous écouter parler anglais. Pour plus de pratique, écoutez le fichier audio que vous avez créé 3 fois aujourd'hui.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 1968,
       "label": "celebration10",
       "translation": "{{emojis}} Lesson complete! Amazing work. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1970,
       "label": "celebration12",
       "translation": "{{emojis}} What a great job. You finished today's lesson! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2153,
       "label": "celebration12",
       "translation": "{{emojis}} What a great job. You finished today's lesson! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2155,
       "label": "celebration14",
       "translation": "{{emojis}} Lesson complete! Your English is getting better everyday! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 1973,
       "label": "celebration15",
       "translation": "{{emojis}} Yeehaw!!! Your lesson is complete! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1974,
       "label": "celebration2",
       "translation": "{{emojis}} Excellent work today, {{name}}. Keep it up! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2158,
       "label": "celebration3",
       "translation": "{{emojis}} You did a great job today, {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2159,
       "label": "celebration4",
       "translation": "{{emojis}} Wow! Impressive effort today, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 1976,
       "label": "celebration4",
       "translation": "{{emojis}} Wow! Impressive effort today, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2160,
       "label": "celebration5",
       "translation": "{{emojis}} Today's lesson is done. Outstanding! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 1978,
       "label": "celebration6",
       "translation": "{{emojis}} Woohoo! You finished today's lesson. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2162,
       "label": "celebration7",
       "translation": "{{emojis}} Your lesson is complete. Terrific job, {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 1980,
       "label": "celebration8",
       "translation": "{{emojis}} Wonderful job, {{name}}! What a great lesson. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2164,
       "label": "celebration9",
       "translation": "{{emojis}} I'm proud of your work today. Thank you for your effort, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2010,
       "label": "transfer1",
       "translation": "*Tarea*: Ahora, vuelve al trabajo y practica las palabras de hoy.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2012,
       "label": "transfer11",
       "translation": "*Tarea*: ¡Ahora, te reto a que practiques hablar inglés en el trabajo!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2013,
       "label": "transfer12",
       "translation": "*Tarea*: ¿Le dijiste a tu gerente que terminaste tu lección? ¡Ve a hablar con ellos si están disponibles y cuéntales qué palabras aprendiste hoy!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2015,
       "label": "transfer14",
       "translation": "*Tarea*: Ok. Aquí hay un consejo para ayudarlo a hablar. Deletrea en voz alta las palabras que aprendiste hoy con tu voz. ¡Di las letras en inglés!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2017,
       "label": "transfer2",
       "translation": "*Tarea*: Ok. Intenta practicar tu palabra 3 veces con un amigo hoy.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2019,
       "label": "transfer4",
       "translation": "*Tarea*: Ahora intenta esto. Mientras esté en el trabajo hoy, escuche las palabras que acaba de aprender.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2021,
       "label": "transfer6",
       "translation": "*Tarea*: Ok! Ahora practica con un compañero de trabajo para seguir mejorando.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2022,
       "label": "transfer7",
       "translation": "*Tarea*: La mejor manera de acelerar sus habilidades para hablar es usar lo que aprendió. Ve a hablar con un compañero de trabajo y practica tus palabras.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2024,
       "label": "transfer9",
       "translation": "*Tarea*: Para mejorar tu pronunciación, es bueno que escuches como tu hablas inglés. Para practicar más, escuche 3 veces el mensaje de voz que mandó.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2193,
       "label": "transfer1",
       "translation": "*Les devoirs:* Maintenant, retournez au travail et répéter les mots d'aujourd'hui.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2195,
       "label": "transfer11",
       "translation": "*Les devoirs:* Maintenant, je vous mets au défi d'utiliser votre anglais au travail!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2196,
       "label": "transfer12",
       "translation": "*Les devoirs:* Avez-vous dit à votre manager que vous avez terminé votre leçon? Allez discuter avec eux s'ils sont disponibles et dites-leur quels mots vous avez appris aujourd'hui!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2198,
       "label": "transfer14",
       "translation": "*Les devoirs:* Ok. Voici un conseil pour vous aider à parler. Épelez à haute voix les mots que vous avez appris aujourd'hui. Dites les lettres en anglais!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2199,
       "label": "transfer15",
       "translation": "*Les devoirs:* Soyez courageux et entraînez-vous à parler! Notez les mots que vous avez appris aujourd'hui sur votre liste de préparation ou votre calendrier.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2202,
       "label": "transfer4",
       "translation": "*Les devoirs:* Maintenant, essayez ceci. Pendant que vous travaillez aujourd'hui, écoutez les mots que vous venez d'apprendre.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2204,
       "label": "transfer6",
       "translation": "*Les devoirs:* Ok! Maintenant, entraînez-vous avec un collègue pour continuer à vous améliorer.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2205,
       "label": "transfer7",
       "translation": "*Les devoirs:* La meilleure façon d'améliorer vos compétences orales est d'utiliser ce que vous avez appris. Allez parler à un collègue et essayez d'utiliser les mots que vous avez appris.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2206,
       "label": "transfer8",
       "translation": "*Les devoirs:* Voici une astuce! Écrivez les nouveaux mots que vous avez appris sur un morceau de ruban adhésif. Mettez la bande dans votre casier et entraînez-vous chaque fois que vous changez votre uniforme!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2219,
-      "label": "tuesday",
-      "translation": "martes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T02:52:30Z",
-      "updated_at": "2020-02-23T02:52:30Z",
-      "language": "es"
-    },
-    {
-      "id": 2605,
-      "label": "during",
-      "translation": "during",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2228,
-      "label": "audio_instructions",
-      "translation": "_Usa WhatsApp para enviar tu mensaje de voz!_ 🎤",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T03:10:47Z",
-      "updated_at": "2020-02-23T03:10:47Z",
-      "language": "es"
-    },
-    {
-      "id": 2229,
-      "label": "audio_instructions",
-      "translation": "_Utilisez WhatsApp pour envoyer votre voix!_ 🎤",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T03:10:58Z",
-      "updated_at": "2020-02-23T03:11:03Z",
-      "language": "fr"
-    },
-    {
-      "id": 2231,
-      "label": "audio_instructions_full",
-      "translation": "_Usa WhatsApp para enviar tu mensaje de voz!_ 🎤\n\n1. Mantenga presionado el micrófono ↘️\n2. Comienza a hablar.\n3. Cuando termines de hablar, retira el dedo del micrófono.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T03:33:44Z",
-      "updated_at": "2020-02-23T03:33:44Z",
-      "language": "es"
-    },
-    {
-      "id": 2232,
-      "label": "audio_instructions_full",
-      "translation": "_Utilisez WhatsApp pour envoyer votre voix! _ 🎤\n\n1. Appuyez et maintenez le microphone ↘️\n2. Commencez à parler.\n3. Lorsque vous avez fini de parler, retirez votre doigt du microphone.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T03:34:00Z",
-      "updated_at": "2020-02-23T03:34:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2225,
-      "label": "thursday",
-      "translation": "jueves",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T03:08:39Z",
-      "updated_at": "2020-02-23T03:08:39Z",
-      "language": "es"
-    },
-    {
-      "id": 2223,
-      "label": "wednesday",
-      "translation": "Mercredi",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T02:58:18Z",
-      "updated_at": "2020-02-23T02:58:18Z",
-      "language": "fr"
-    },
-    {
-      "id": 2222,
-      "label": "wednesday",
-      "translation": "miércoles",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T02:58:12Z",
-      "updated_at": "2020-02-23T02:58:12Z",
-      "language": "es"
-    },
-    {
-      "id": 2221,
-      "label": "wednesday",
-      "translation": "Wednesday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T02:58:05Z",
-      "updated_at": "2020-02-23T02:58:05Z",
-      "language": "en"
-    },
-    {
-      "id": 2220,
-      "label": "tuesday",
-      "translation": "Mardi",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T02:52:42Z",
-      "updated_at": "2020-02-23T02:53:02Z",
-      "language": "fr"
-    },
-    {
-      "id": 2218,
-      "label": "tuesday",
-      "translation": "Tuesday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T02:52:20Z",
-      "updated_at": "2020-02-23T02:52:20Z",
-      "language": "en"
-    },
-    {
-      "id": 1994,
       "label": "match_correct_answer",
       "translation": "🤖 ¡Correcto! {{emojis}}",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2327,
-      "label": "black",
-      "translation": "negro",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:27:28Z",
-      "updated_at": "2020-02-23T05:27:28Z",
-      "language": "es"
-    },
-    {
-      "id": 2326,
-      "label": "black",
-      "translation": "black",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:27:22Z",
-      "updated_at": "2020-02-23T05:27:22Z",
-      "language": "en"
-    },
-    {
-      "id": 2324,
-      "label": "stir",
-      "translation": "remover",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:26:56Z",
-      "updated_at": "2020-02-23T05:26:56Z",
-      "language": "es"
-    },
-    {
-      "id": 2323,
-      "label": "stir",
-      "translation": "stir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:26:48Z",
-      "updated_at": "2020-02-23T05:26:48Z",
-      "language": "en"
-    },
-    {
-      "id": 2322,
-      "label": "quart_container",
-      "translation": "récipient de quart",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:26:13Z",
-      "updated_at": "2020-02-23T05:26:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2321,
-      "label": "quart_container",
-      "translation": "contenedor del cuarto de galón",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:26:06Z",
-      "updated_at": "2020-02-23T05:26:06Z",
-      "language": "es"
-    },
-    {
-      "id": 2320,
-      "label": "quart_container",
-      "translation": "quart container",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:25:46Z",
-      "updated_at": "2020-02-23T05:25:46Z",
-      "language": "en"
-    },
-    {
-      "id": 2319,
-      "label": "put",
-      "translation": "mettre, poser",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:25:18Z",
-      "updated_at": "2020-02-23T05:25:18Z",
-      "language": "fr"
-    },
-    {
-      "id": 2318,
-      "label": "put",
-      "translation": "poner",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:25:05Z",
-      "updated_at": "2020-02-23T05:25:05Z",
-      "language": "es"
-    },
-    {
-      "id": 2317,
-      "label": "put",
-      "translation": "put",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:24:59Z",
-      "updated_at": "2020-02-23T05:24:59Z",
-      "language": "en"
-    },
-    {
-      "id": 2316,
-      "label": "serve",
-      "translation": "servir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:24:33Z",
-      "updated_at": "2020-02-23T05:24:33Z",
-      "language": "fr"
-    },
-    {
-      "id": 2315,
-      "label": "serve",
-      "translation": "servir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:24:25Z",
-      "updated_at": "2020-02-23T05:24:25Z",
-      "language": "es"
-    },
-    {
-      "id": 2314,
-      "label": "serve",
-      "translation": "serve",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:24:18Z",
-      "updated_at": "2020-02-23T05:24:18Z",
-      "language": "en"
-    },
-    {
-      "id": 2313,
-      "label": "sift",
-      "translation": "tamiser",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:24:04Z",
-      "updated_at": "2020-02-23T05:24:04Z",
-      "language": "fr"
-    },
-    {
-      "id": 2312,
-      "label": "sift",
-      "translation": "tamizar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:23:56Z",
-      "updated_at": "2020-02-23T05:23:56Z",
-      "language": "es"
-    },
-    {
-      "id": 2311,
-      "label": "sift",
-      "translation": "sift",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:23:51Z",
-      "updated_at": "2020-02-23T05:23:51Z",
-      "language": "en"
-    },
-    {
-      "id": 2310,
-      "label": "carry",
-      "translation": "apporter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:23:36Z",
-      "updated_at": "2020-02-23T05:23:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 2309,
-      "label": "carry",
-      "translation": "llevar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:23:29Z",
-      "updated_at": "2020-02-23T05:23:29Z",
-      "language": "es"
-    },
-    {
-      "id": 2308,
-      "label": "carry",
-      "translation": "carry",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:23:24Z",
-      "updated_at": "2020-02-23T05:23:24Z",
-      "language": "en"
-    },
-    {
-      "id": 2307,
-      "label": "work",
-      "translation": "travailler",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:23:11Z",
-      "updated_at": "2020-02-23T05:23:11Z",
-      "language": "fr"
-    },
-    {
-      "id": 2306,
-      "label": "work",
-      "translation": "trabajar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:23:02Z",
-      "updated_at": "2020-02-23T05:23:02Z",
-      "language": "es"
-    },
-    {
-      "id": 2305,
-      "label": "work",
-      "translation": "work",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:22:58Z",
-      "updated_at": "2020-02-23T05:22:58Z",
-      "language": "en"
-    },
-    {
-      "id": 2304,
-      "label": "want",
-      "translation": "vouloir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:22:45Z",
-      "updated_at": "2020-02-23T05:22:45Z",
-      "language": "fr"
-    },
-    {
-      "id": 2303,
-      "label": "want",
-      "translation": "querer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:22:38Z",
-      "updated_at": "2020-02-23T05:22:38Z",
-      "language": "es"
-    },
-    {
-      "id": 2302,
-      "label": "want",
-      "translation": "want",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:22:33Z",
-      "updated_at": "2020-02-23T05:22:33Z",
-      "language": "en"
-    },
-    {
-      "id": 2301,
-      "label": "these",
-      "translation": "ces",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:22:16Z",
-      "updated_at": "2020-02-23T05:22:16Z",
-      "language": "fr"
-    },
-    {
-      "id": 2300,
-      "label": "these",
-      "translation": "estos",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:22:09Z",
-      "updated_at": "2020-02-23T05:22:09Z",
-      "language": "es"
-    },
-    {
-      "id": 2299,
-      "label": "these",
-      "translation": "these",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:22:04Z",
-      "updated_at": "2020-02-23T05:22:04Z",
-      "language": "en"
-    },
-    {
-      "id": 2298,
-      "label": "cook",
-      "translation": "cuisiner",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:21:48Z",
-      "updated_at": "2020-02-23T05:21:48Z",
-      "language": "fr"
-    },
-    {
-      "id": 2297,
-      "label": "cook",
-      "translation": "cocinar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:21:40Z",
-      "updated_at": "2020-02-23T05:21:40Z",
-      "language": "es"
-    },
-    {
-      "id": 2296,
-      "label": "cook",
-      "translation": "cook",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:21:34Z",
-      "updated_at": "2020-02-23T05:21:34Z",
-      "language": "en"
-    },
-    {
-      "id": 2295,
-      "label": "need",
-      "translation": "avoir besoin",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:21:12Z",
-      "updated_at": "2020-02-23T05:21:12Z",
-      "language": "fr"
-    },
-    {
-      "id": 2294,
-      "label": "need",
-      "translation": "necesitar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:21:02Z",
-      "updated_at": "2020-02-23T05:21:02Z",
-      "language": "es"
-    },
-    {
-      "id": 2293,
-      "label": "need",
-      "translation": "need",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:20:50Z",
-      "updated_at": "2020-02-23T05:20:50Z",
-      "language": "en"
-    },
-    {
-      "id": 2292,
-      "label": "that",
-      "translation": "ça",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:20:11Z",
-      "updated_at": "2020-02-23T05:20:11Z",
-      "language": "fr"
-    },
-    {
-      "id": 2291,
-      "label": "that",
-      "translation": "ese",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:20:00Z",
-      "updated_at": "2020-02-23T05:20:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2290,
-      "label": "that",
-      "translation": "that",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:19:54Z",
-      "updated_at": "2020-02-23T05:19:54Z",
-      "language": "en"
-    },
-    {
-      "id": 2289,
-      "label": "drain",
-      "translation": "égoutter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:19:42Z",
-      "updated_at": "2020-02-23T05:19:42Z",
-      "language": "fr"
-    },
-    {
-      "id": 2288,
-      "label": "drain",
-      "translation": "escurrir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:19:34Z",
-      "updated_at": "2020-02-23T05:19:34Z",
-      "language": "es"
-    },
-    {
-      "id": 2287,
-      "label": "drain",
-      "translation": "drain",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:19:25Z",
-      "updated_at": "2020-02-23T05:19:25Z",
-      "language": "en"
-    },
-    {
-      "id": 2286,
-      "label": "flip",
-      "translation": "retourner",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:19:06Z",
-      "updated_at": "2020-02-23T05:19:06Z",
-      "language": "fr"
-    },
-    {
-      "id": 2285,
-      "label": "flip",
-      "translation": "voltear",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:18:58Z",
-      "updated_at": "2020-02-23T05:18:58Z",
-      "language": "es"
-    },
-    {
-      "id": 2284,
-      "label": "flip",
-      "translation": "flip",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:18:48Z",
-      "updated_at": "2020-02-23T05:18:48Z",
-      "language": "en"
-    },
-    {
-      "id": 2283,
-      "label": "hold",
-      "translation": "tenir bon",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:18:26Z",
-      "updated_at": "2020-02-23T05:18:26Z",
-      "language": "fr"
-    },
-    {
-      "id": 2282,
-      "label": "hold",
-      "translation": "sostener",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:17:57Z",
-      "updated_at": "2020-02-23T05:17:57Z",
-      "language": "es"
-    },
-    {
-      "id": 2281,
-      "label": "hold",
-      "translation": "hold",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:17:52Z",
-      "updated_at": "2020-02-23T05:17:52Z",
-      "language": "en"
-    },
-    {
-      "id": 2279,
-      "label": "important",
-      "translation": "importante",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:17:28Z",
-      "updated_at": "2020-02-23T05:17:28Z",
-      "language": "es"
-    },
-    {
-      "id": 2278,
-      "label": "important",
-      "translation": "important",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:17:22Z",
-      "updated_at": "2020-02-23T05:17:22Z",
-      "language": "en"
-    },
-    {
-      "id": 2277,
-      "label": "this",
-      "translation": "cette",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:16:53Z",
-      "updated_at": "2020-02-23T05:16:53Z",
-      "language": "fr"
-    },
-    {
-      "id": 2276,
-      "label": "this",
-      "translation": "esto",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:16:45Z",
-      "updated_at": "2020-02-23T05:16:45Z",
-      "language": "es"
-    },
-    {
-      "id": 2275,
-      "label": "this",
-      "translation": "this",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:16:39Z",
-      "updated_at": "2020-02-23T05:16:39Z",
-      "language": "en"
-    },
-    {
-      "id": 2274,
-      "label": "empty",
-      "translation": "vide",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:16:22Z",
-      "updated_at": "2020-02-23T05:16:22Z",
-      "language": "fr"
-    },
-    {
-      "id": 2273,
-      "label": "empty",
-      "translation": "vacío",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:16:14Z",
-      "updated_at": "2020-02-23T05:16:14Z",
-      "language": "es"
-    },
-    {
-      "id": 2272,
-      "label": "empty",
-      "translation": "empty",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:16:04Z",
-      "updated_at": "2020-02-23T05:16:04Z",
-      "language": "en"
-    },
-    {
-      "id": 2271,
-      "label": "have",
-      "translation": "avoir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:15:42Z",
-      "updated_at": "2020-02-23T05:15:42Z",
-      "language": "fr"
-    },
-    {
-      "id": 2270,
-      "label": "have",
-      "translation": "tener",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:15:34Z",
-      "updated_at": "2020-02-23T05:15:34Z",
-      "language": "es"
-    },
-    {
-      "id": 2269,
-      "label": "have",
-      "translation": "have",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:15:29Z",
-      "updated_at": "2020-02-23T05:15:29Z",
-      "language": "en"
-    },
-    {
-      "id": 2268,
-      "label": "full",
-      "translation": "plein",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:15:15Z",
-      "updated_at": "2020-02-23T05:15:15Z",
-      "language": "fr"
-    },
-    {
-      "id": 2267,
-      "label": "full",
-      "translation": "lleno",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:15:05Z",
-      "updated_at": "2020-02-23T05:15:05Z",
-      "language": "es"
-    },
-    {
-      "id": 2266,
-      "label": "full",
-      "translation": "full",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:14:59Z",
-      "updated_at": "2020-02-23T05:14:59Z",
-      "language": "en"
-    },
-    {
-      "id": 2265,
-      "label": "there_are",
-      "translation": "il y a",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:14:31Z",
-      "updated_at": "2020-02-23T05:14:31Z",
-      "language": "fr"
-    },
-    {
-      "id": 2264,
-      "label": "there_are",
-      "translation": "hay",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:14:17Z",
-      "updated_at": "2020-02-23T05:14:17Z",
-      "language": "es"
-    },
-    {
-      "id": 2263,
-      "label": "there_are",
-      "translation": "there are",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:14:14Z",
-      "updated_at": "2020-02-23T05:14:14Z",
-      "language": "en"
-    },
-    {
-      "id": 2262,
-      "label": "apron",
-      "translation": "tablier",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:13:51Z",
-      "updated_at": "2020-02-23T05:13:51Z",
-      "language": "fr"
-    },
-    {
-      "id": 2261,
-      "label": "apron",
-      "translation": "delantal",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:13:42Z",
-      "updated_at": "2020-02-23T05:13:42Z",
-      "language": "es"
-    },
-    {
-      "id": 2260,
-      "label": "apron",
-      "translation": "apron",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:13:38Z",
-      "updated_at": "2020-02-23T05:13:38Z",
-      "language": "en"
-    },
-    {
-      "id": 2259,
-      "label": "there_is",
-      "translation": "il y a",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:13:15Z",
-      "updated_at": "2020-02-23T05:13:15Z",
-      "language": "fr"
-    },
-    {
-      "id": 2258,
-      "label": "there_is",
-      "translation": "hay",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:13:04Z",
-      "updated_at": "2020-02-23T05:13:04Z",
-      "language": "es"
-    },
-    {
-      "id": 2257,
-      "label": "there_is",
-      "translation": "there is",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:12:59Z",
-      "updated_at": "2020-02-23T05:12:59Z",
-      "language": "en"
-    },
-    {
-      "id": 2256,
-      "label": "gloves",
-      "translation": "gants",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:12:44Z",
-      "updated_at": "2020-02-23T05:12:44Z",
-      "language": "fr"
-    },
-    {
-      "id": 2255,
-      "label": "gloves",
-      "translation": "guantes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:12:28Z",
-      "updated_at": "2020-02-23T05:12:28Z",
-      "language": "es"
-    },
-    {
-      "id": 2254,
-      "label": "gloves",
-      "translation": "gloves",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:12:24Z",
-      "updated_at": "2020-02-23T05:12:24Z",
-      "language": "en"
-    },
-    {
-      "id": 2253,
-      "label": "fast",
-      "translation": "vite",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:53:52Z",
-      "updated_at": "2020-02-23T04:53:52Z",
-      "language": "fr"
-    },
-    {
-      "id": 2252,
-      "label": "fast",
-      "translation": "rápido",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:53:48Z",
-      "updated_at": "2020-02-23T04:53:48Z",
-      "language": "es"
-    },
-    {
-      "id": 2251,
-      "label": "fast",
-      "translation": "fast",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:53:44Z",
-      "updated_at": "2020-02-23T04:53:44Z",
-      "language": "en"
-    },
-    {
-      "id": 2250,
-      "label": "slow",
-      "translation": "lent",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:53:02Z",
-      "updated_at": "2020-02-23T04:53:02Z",
-      "language": "fr"
-    },
-    {
-      "id": 2249,
-      "label": "slow",
-      "translation": "lento",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:52:58Z",
-      "updated_at": "2020-02-23T04:52:58Z",
-      "language": "es"
-    },
-    {
-      "id": 2248,
-      "label": "slow",
-      "translation": "slow",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:52:53Z",
-      "updated_at": "2020-02-23T04:52:53Z",
-      "language": "en"
-    },
-    {
-      "id": 2247,
-      "label": "hairnet",
-      "translation": "redecilla",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:52:14Z",
-      "updated_at": "2020-02-23T04:52:14Z",
-      "language": "es"
-    },
-    {
-      "id": 2246,
-      "label": "hairnet",
-      "translation": "résille",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:52:02Z",
-      "updated_at": "2020-02-23T04:52:02Z",
-      "language": "fr"
-    },
-    {
-      "id": 2245,
-      "label": "hairnet",
-      "translation": "hairnet",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:51:57Z",
-      "updated_at": "2020-02-23T04:51:57Z",
-      "language": "en"
-    },
-    {
-      "id": 2244,
-      "label": "late",
-      "translation": "en retard",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:27:41Z",
-      "updated_at": "2020-02-23T04:27:41Z",
-      "language": "fr"
-    },
-    {
-      "id": 2243,
-      "label": "late",
-      "translation": "tarde",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:27:27Z",
-      "updated_at": "2020-02-23T04:27:27Z",
-      "language": "es"
-    },
-    {
-      "id": 2242,
-      "label": "late",
-      "translation": "late",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:27:18Z",
-      "updated_at": "2020-02-23T04:27:18Z",
-      "language": "en"
-    },
-    {
-      "id": 2241,
-      "label": "wrong",
-      "translation": "faux",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:24:21Z",
-      "updated_at": "2020-02-23T04:24:21Z",
-      "language": "fr"
-    },
-    {
-      "id": 2240,
-      "label": "wrong",
-      "translation": "incorrecto",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:24:01Z",
-      "updated_at": "2020-02-23T04:24:01Z",
-      "language": "es"
-    },
-    {
-      "id": 2239,
-      "label": "wrong",
-      "translation": "wrong",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:23:55Z",
-      "updated_at": "2020-02-23T04:23:55Z",
-      "language": "en"
-    },
-    {
-      "id": 2238,
-      "label": "yellow",
-      "translation": "jaune",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:17:26Z",
-      "updated_at": "2020-02-23T04:17:26Z",
-      "language": "fr"
-    },
-    {
-      "id": 2237,
-      "label": "yellow",
-      "translation": "amarillo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:17:14Z",
-      "updated_at": "2020-02-23T04:17:14Z",
-      "language": "es"
-    },
-    {
-      "id": 2236,
-      "label": "yellow",
-      "translation": "yellow",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:17:08Z",
-      "updated_at": "2020-02-23T04:17:08Z",
-      "language": "en"
-    },
-    {
-      "id": 2235,
-      "label": "red",
-      "translation": "rouge",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:15:35Z",
-      "updated_at": "2020-02-23T04:15:35Z",
-      "language": "fr"
-    },
-    {
-      "id": 2234,
-      "label": "red",
-      "translation": "rojo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:15:30Z",
-      "updated_at": "2020-02-23T04:15:30Z",
-      "language": "es"
-    },
-    {
-      "id": 2233,
-      "label": "red",
-      "translation": "red",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T04:15:22Z",
-      "updated_at": "2020-02-23T04:15:22Z",
-      "language": "en"
-    },
-    {
-      "id": 2339,
-      "label": "uniform",
-      "translation": "uniforme",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:29:59Z",
-      "updated_at": "2020-02-23T05:29:59Z",
-      "language": "es"
-    },
-    {
-      "id": 2329,
-      "label": "pour",
-      "translation": "pour",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:27:56Z",
-      "updated_at": "2020-02-23T05:27:56Z",
-      "language": "en"
-    },
-    {
-      "id": 2606,
-      "label": "eggplant",
-      "translation": "eggplant",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2607,
-      "label": "sometimes",
-      "translation": "sometimes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2608,
-      "label": "soon",
-      "translation": "soon",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2609,
-      "label": "each",
-      "translation": "each",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2610,
-      "label": "peeler",
-      "translation": "peeler",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2611,
-      "label": "never",
-      "translation": "never",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2612,
-      "label": "on_top_of",
-      "translation": "on top of",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2613,
-      "label": "in_back_of",
-      "translation": "in back of",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2614,
-      "label": "in_front_of",
-      "translation": "in front of",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2615,
-      "label": "extra_work",
-      "translation": "extra work",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2616,
-      "label": "polish_glasses",
-      "translation": "polish glasses",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2617,
-      "label": "fill_the_salt_and_pepper",
-      "translation": "fill the salt and pepper",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2618,
-      "label": "clean",
-      "translation": "clean",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2619,
-      "label": "start",
-      "translation": "start",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2620,
-      "label": "oven",
-      "translation": "oven",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2621,
-      "label": "shift",
-      "translation": "shift",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2622,
-      "label": "refrigerator",
-      "translation": "refrigerator",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2623,
-      "label": "fryer",
-      "translation": "fryer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2624,
-      "label": "hood",
-      "translation": "hood",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2625,
-      "label": "dishwasher",
-      "translation": "dishwasher",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2628,
-      "label": "look_for",
-      "translation": "look for",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2629,
-      "label": "prep_cook",
-      "translation": "prep cook",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2630,
-      "label": "line_cook",
-      "translation": "line cook",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2631,
-      "label": "follow_the_recipe",
-      "translation": "follow the recipe",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2632,
-      "label": "prepare",
-      "translation": "prepare",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2633,
-      "label": "practice",
-      "translation": "practice",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2634,
-      "label": "make_sure",
-      "translation": "make sure",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2635,
-      "label": "vegetables",
-      "translation": "vegetables",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2636,
-      "label": "garlic",
-      "translation": "garlic",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2637,
-      "label": "mushrooms",
-      "translation": "mushrooms",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2638,
-      "label": "give",
-      "translation": "give",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2639,
-      "label": "bring",
-      "translation": "bring",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2640,
-      "label": "find",
-      "translation": "find",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2641,
-      "label": "move",
-      "translation": "move",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2642,
-      "label": "tomatoes",
-      "translation": "tomatoes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2643,
-      "label": "zucchini",
-      "translation": "zucchini",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2644,
-      "label": "potatoes",
-      "translation": "potatoes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2645,
-      "label": "ladle",
-      "translation": "ladle",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2646,
-      "label": "peppers",
-      "translation": "peppers",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2647,
-      "label": "colander",
-      "translation": "colander",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2648,
-      "label": "whisk",
-      "translation": "whisk",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2649,
-      "label": "tongs",
-      "translation": "tongs",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2650,
-      "label": "filter",
-      "translation": "filter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2651,
-      "label": "ingredients",
-      "translation": "ingredients",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2652,
-      "label": "sauce",
-      "translation": "sauce",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2653,
-      "label": "broth",
-      "translation": "broth",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2654,
-      "label": "parsley",
-      "translation": "parsley",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2655,
-      "label": "garnish",
-      "translation": "garnish",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2656,
-      "label": "quart",
-      "translation": "quart",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2657,
-      "label": "pound",
-      "translation": "pound",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2658,
-      "label": "ounce",
-      "translation": "ounce",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2659,
-      "label": "weigh",
-      "translation": "weigh",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2660,
-      "label": "liter",
-      "translation": "liter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2661,
-      "label": "steam",
-      "translation": "steam",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2662,
-      "label": "melt",
-      "translation": "melt",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2663,
-      "label": "brown",
-      "translation": "brown",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2664,
-      "label": "poach",
-      "translation": "poach",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2665,
-      "label": "irritated",
-      "translation": "irritated",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2666,
-      "label": "amazed",
-      "translation": "amazed",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2667,
-      "label": "worried",
-      "translation": "worried",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2668,
-      "label": "be_conscience_of",
-      "translation": "be conscience of",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2669,
-      "label": "on_time",
-      "translation": "on time",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2670,
-      "label": "training",
-      "translation": "training",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2671,
-      "label": "shake",
-      "translation": "shake",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2672,
-      "label": "finished",
-      "translation": "finished",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2673,
-      "label": "still",
-      "translation": "still",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2674,
-      "label": "silverware_rollup",
-      "translation": "silverware rollup",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2675,
-      "label": "stack",
-      "translation": "stack",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2676,
-      "label": "ask_for",
-      "translation": "pedir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2677,
-      "label": "appear",
-      "translation": "aparecer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2679,
-      "label": "listen",
-      "translation": "escuchar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2680,
-      "label": "pay_attention",
-      "translation": "poner atención",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2681,
-      "label": "since",
-      "translation": "desde",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2682,
-      "label": "during",
-      "translation": "durante",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2683,
-      "label": "eggplant",
-      "translation": "berenjena",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2684,
-      "label": "sometimes",
-      "translation": "a veces",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2685,
-      "label": "soon",
-      "translation": "pronto",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2686,
-      "label": "each",
-      "translation": "cada",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2687,
-      "label": "peeler",
-      "translation": "pelador",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2688,
-      "label": "never",
-      "translation": "nunca",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2689,
-      "label": "on_top_of",
-      "translation": "encima de",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2690,
-      "label": "in_back_of",
-      "translation": "detrás de",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2691,
-      "label": "in_front_of",
-      "translation": "en frente de",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2692,
-      "label": "extra_work",
-      "translation": "trabajo extra",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2693,
-      "label": "polish_glasses",
-      "translation": "pulir vasos",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2694,
-      "label": "fill_the_salt_and_pepper",
-      "translation": "llenar la sal y la pimienta",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2695,
-      "label": "clean",
-      "translation": "limpiar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2696,
-      "label": "start",
-      "translation": "comenzar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2697,
-      "label": "oven",
-      "translation": "horno",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2334,
-      "label": "early",
-      "translation": "tôt",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:28:44Z",
-      "updated_at": "2020-02-23T05:28:44Z",
-      "language": "fr"
-    },
-    {
-      "id": 2333,
-      "label": "early",
-      "translation": "temprano",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:28:31Z",
-      "updated_at": "2020-02-23T05:28:31Z",
-      "language": "es"
-    },
-    {
-      "id": 2331,
-      "label": "pour",
-      "translation": "verser",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:28:11Z",
-      "updated_at": "2020-02-23T05:28:11Z",
-      "language": "fr"
-    },
-    {
-      "id": 2330,
-      "label": "pour",
-      "translation": "verter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:28:03Z",
-      "updated_at": "2020-02-23T05:28:03Z",
-      "language": "es"
-    },
-    {
-      "id": 2698,
-      "label": "shift",
-      "translation": "turno de trabajo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2699,
-      "label": "refrigerator",
-      "translation": "refrigerador",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2700,
-      "label": "fryer",
-      "translation": "freidora",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2701,
-      "label": "hood",
-      "translation": "campana extractora",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2702,
-      "label": "dishwasher",
-      "translation": "lavaplatos",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2705,
-      "label": "look_for",
-      "translation": "buscar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2706,
-      "label": "prep_cook",
-      "translation": "cocinero de preparación",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2707,
-      "label": "line_cook",
-      "translation": "cocinero del linea",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2708,
-      "label": "follow_the_recipe",
-      "translation": "seguir la receta",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2709,
-      "label": "prepare",
-      "translation": "preparar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2710,
-      "label": "practice",
-      "translation": "practicar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2711,
-      "label": "make_sure",
-      "translation": "asegurarse",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2712,
-      "label": "vegetables",
-      "translation": "vegetales",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2713,
-      "label": "garlic",
-      "translation": "ajo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2714,
-      "label": "mushrooms",
-      "translation": "champiñones",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2715,
-      "label": "give",
-      "translation": "dar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2716,
-      "label": "bring",
-      "translation": "traer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2717,
-      "label": "find",
-      "translation": "encontrar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2718,
-      "label": "move",
-      "translation": "mover",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2719,
-      "label": "tomatoes",
-      "translation": "tomates",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2720,
-      "label": "zucchini",
-      "translation": "calabacín",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2721,
-      "label": "potatoes",
-      "translation": "patatas",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2722,
-      "label": "ladle",
-      "translation": "cucharón",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2723,
-      "label": "peppers",
-      "translation": "pimientos",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2724,
-      "label": "colander",
-      "translation": "colador",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2725,
-      "label": "whisk",
-      "translation": "batidor",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2726,
-      "label": "tongs",
-      "translation": "tenazas",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2727,
-      "label": "filter",
-      "translation": "filtro",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2728,
-      "label": "ingredients",
-      "translation": "ingredientes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2729,
-      "label": "sauce",
-      "translation": "salsa",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2730,
-      "label": "broth",
-      "translation": "caldo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2731,
-      "label": "parsley",
-      "translation": "perejil",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2732,
-      "label": "garnish",
-      "translation": "guarnición",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2733,
-      "label": "quart",
-      "translation": "cuarto de galón",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2734,
-      "label": "pound",
-      "translation": "libra",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2735,
-      "label": "ounce",
-      "translation": "onza",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2736,
-      "label": "weigh",
-      "translation": "pesar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2737,
-      "label": "liter",
-      "translation": "litro",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2738,
-      "label": "steam",
-      "translation": "cocer al vapor",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2739,
-      "label": "melt",
-      "translation": "fundir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2741,
-      "label": "poach",
-      "translation": "escalfar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2742,
-      "label": "irritated",
-      "translation": "irritado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2743,
-      "label": "amazed",
-      "translation": "asombrado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2744,
-      "label": "worried",
-      "translation": "preocupado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2745,
-      "label": "be_conscience_of",
-      "translation": "ser consciente de",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2746,
-      "label": "on_time",
-      "translation": "a tiempo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2747,
-      "label": "training",
-      "translation": "formación",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2748,
-      "label": "shake",
-      "translation": "batir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2749,
-      "label": "finished",
-      "translation": "acabar de",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2750,
-      "label": "still",
-      "translation": "todavía",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2751,
-      "label": "silverware_rollup",
-      "translation": "enrollar cubierto",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2752,
-      "label": "stack",
-      "translation": "apilar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2753,
-      "label": "ask_for",
-      "translation": "demander",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2754,
-      "label": "appear",
-      "translation": "apparaître",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2756,
-      "label": "listen",
-      "translation": "écouter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2757,
-      "label": "pay_attention",
-      "translation": "faites attention",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2758,
-      "label": "since",
-      "translation": "depuis",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2759,
-      "label": "during",
-      "translation": "durante",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2760,
-      "label": "eggplant",
-      "translation": "aubergine",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2761,
-      "label": "sometimes",
-      "translation": "parfois",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2762,
-      "label": "soon",
-      "translation": "bientôt",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2763,
-      "label": "each",
-      "translation": "tous",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2764,
-      "label": "peeler",
-      "translation": "éplucheur",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2765,
-      "label": "never",
-      "translation": "jamais",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2766,
-      "label": "on_top_of",
-      "translation": "sur",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2767,
-      "label": "in_back_of",
-      "translation": "derrière",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2768,
-      "label": "in_front_of",
-      "translation": "en face de",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2769,
-      "label": "extra_work",
-      "translation": "travail supplémentaire",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2770,
-      "label": "polish_glasses",
-      "translation": "verres polonais",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2771,
-      "label": "fill_the_salt_and_pepper",
-      "translation": "remplir de sel et de poivre",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2772,
-      "label": "clean",
-      "translation": "nettoyer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2773,
-      "label": "start",
-      "translation": "commencer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2774,
-      "label": "oven",
-      "translation": "four",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2775,
-      "label": "shift",
-      "translation": "quart de travail",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2776,
-      "label": "refrigerator",
-      "translation": "réfrigérateur",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2777,
-      "label": "fryer",
-      "translation": "friteuse",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2778,
-      "label": "hood",
-      "translation": "hotte aspirante",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2779,
-      "label": "dishwasher",
-      "translation": "laveuse",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2782,
-      "label": "look_for",
-      "translation": "chercher",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2783,
-      "label": "prep_cook",
-      "translation": "chef de préparation",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2784,
-      "label": "line_cook",
-      "translation": "cuisinière à la chaîne",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2703,
-      "label": "monday",
-      "translation": "lunes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2704,
-      "label": "friday",
-      "translation": "viernes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2781,
-      "label": "friday",
-      "translation": "Vendredi",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2740,
-      "label": "brown",
-      "translation": "marrón",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-29T22:03:41Z",
-      "language": "es"
-    },
-    {
-      "id": 2785,
-      "label": "follow_the_recipe",
-      "translation": "suivez la recette",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2352,
-      "label": "busy",
-      "translation": "occupé",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:32:34Z",
-      "updated_at": "2020-02-23T05:32:34Z",
-      "language": "fr"
-    },
-    {
-      "id": 2351,
-      "label": "busy",
-      "translation": "ocupado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:32:29Z",
-      "updated_at": "2020-02-23T05:32:29Z",
-      "language": "es"
-    },
-    {
-      "id": 2350,
-      "label": "busy",
-      "translation": "busy",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:32:22Z",
-      "updated_at": "2020-02-23T05:32:22Z",
-      "language": "en"
-    },
-    {
-      "id": 2349,
-      "label": "right",
-      "translation": "c'est correct",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:32:03Z",
-      "updated_at": "2020-02-23T05:32:07Z",
-      "language": "fr"
-    },
-    {
-      "id": 2348,
-      "label": "right",
-      "translation": "correcto",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:31:53Z",
-      "updated_at": "2020-02-23T05:31:53Z",
-      "language": "es"
-    },
-    {
-      "id": 2346,
-      "label": "black_and_white",
-      "translation": "en noir et blanc",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:31:23Z",
-      "updated_at": "2020-02-23T05:31:23Z",
-      "language": "fr"
-    },
-    {
-      "id": 2345,
-      "label": "black_and_white",
-      "translation": "en negro y blanco ",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:31:16Z",
-      "updated_at": "2020-02-23T05:31:16Z",
-      "language": "es"
-    },
-    {
-      "id": 2340,
-      "label": "uniform",
-      "translation": "uniforme",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:30:07Z",
-      "updated_at": "2020-02-23T05:30:07Z",
-      "language": "fr"
-    },
-    {
-      "id": 2337,
-      "label": "wear",
-      "translation": "porter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:29:34Z",
-      "updated_at": "2020-02-23T05:29:34Z",
-      "language": "fr"
-    },
-    {
-      "id": 2336,
-      "label": "wear",
-      "translation": "usar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:29:14Z",
-      "updated_at": "2020-02-23T05:29:14Z",
-      "language": "es"
-    },
-    {
-      "id": 2335,
-      "label": "wear",
-      "translation": "wear",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:29:10Z",
-      "updated_at": "2020-02-23T05:29:10Z",
-      "language": "en"
-    },
-    {
-      "id": 2332,
-      "label": "early",
-      "translation": "early",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:28:26Z",
-      "updated_at": "2020-02-23T05:28:26Z",
-      "language": "en"
-    },
-    {
-      "id": 2786,
-      "label": "prepare",
-      "translation": "préparer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2787,
-      "label": "practice",
-      "translation": "pratiquer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2788,
-      "label": "make_sure",
-      "translation": "assurez-vous",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2789,
-      "label": "vegetables",
-      "translation": "légumes",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2790,
-      "label": "garlic",
-      "translation": "l'ail",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2791,
-      "label": "mushrooms",
-      "translation": "champignons",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2792,
-      "label": "give",
-      "translation": "donner",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2793,
-      "label": "bring",
-      "translation": "apporter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2794,
-      "label": "find",
-      "translation": "trouver",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2795,
-      "label": "move",
-      "translation": "bouger",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2796,
-      "label": "tomatoes",
-      "translation": "tomates",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2797,
-      "label": "zucchini",
-      "translation": "courgette",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2798,
-      "label": "potatoes",
-      "translation": "pommes de terre",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2799,
-      "label": "ladle",
-      "translation": "louche",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2800,
-      "label": "peppers",
-      "translation": "poivrons",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2801,
-      "label": "colander",
-      "translation": "passoire",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2802,
-      "label": "whisk",
-      "translation": "fouetter",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2803,
-      "label": "tongs",
-      "translation": "tenailles",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2804,
-      "label": "filter",
-      "translation": "filtrer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2805,
-      "label": "ingredients",
-      "translation": "ingrédients",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2806,
-      "label": "sauce",
-      "translation": "sauce",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2807,
-      "label": "broth",
-      "translation": "bouillon",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2808,
-      "label": "parsley",
-      "translation": "persil",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2809,
-      "label": "garnish",
-      "translation": "garnir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2810,
-      "label": "quart",
-      "translation": "quart",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2811,
-      "label": "pound",
-      "translation": "livre",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2812,
-      "label": "ounce",
-      "translation": "once",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2813,
-      "label": "weigh",
-      "translation": "regret",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2814,
-      "label": "liter",
-      "translation": "litre",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2815,
-      "label": "steam",
-      "translation": "fumant",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2816,
-      "label": "melt",
-      "translation": "fondre",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2817,
-      "label": "brown",
-      "translation": "brun",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2818,
-      "label": "poach",
-      "translation": "braconner",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2819,
-      "label": "irritated",
-      "translation": "irrité",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2820,
-      "label": "amazed",
-      "translation": "étonné",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2821,
-      "label": "worried",
-      "translation": "inquiet",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2822,
-      "label": "be_conscience_of",
-      "translation": "être conscient de",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2823,
-      "label": "on_time",
-      "translation": "à temps",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2824,
-      "label": "training",
-      "translation": "formation",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2825,
-      "label": "shake",
-      "translation": "battre",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2826,
-      "label": "finished",
-      "translation": "finir de",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2827,
-      "label": "still",
-      "translation": "encore",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2828,
-      "label": "silverware_rollup",
-      "translation": "rouleau couvert",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2829,
-      "label": "stack",
-      "translation": "pile",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2892,
-      "label": "i_need",
-      "translation": "I need",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T02:57:56Z",
-      "updated_at": "2020-02-24T02:57:56Z",
-      "language": "en"
-    },
-    {
-      "id": 2937,
-      "label": "wheat_gluten",
-      "translation": "gluten de blé\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:29:32Z",
-      "updated_at": "2020-02-29T21:29:32Z",
-      "language": "fr"
-    },
-    {
-      "id": 2939,
-      "label": "nuts",
-      "translation": "noix",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:29:59Z",
-      "updated_at": "2020-02-29T21:29:59Z",
-      "language": "fr"
-    },
-    {
-      "id": 2942,
-      "label": "soy",
-      "translation": "soya",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:31:26Z",
-      "updated_at": "2020-02-29T21:31:26Z",
-      "language": "es"
-    },
-    {
-      "id": 2948,
-      "label": "mixing_bowl",
-      "translation": "tazón",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:33:00Z",
-      "updated_at": "2020-02-29T21:33:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2898,
-      "label": "did_you_like_your_first_lesson_what_would_you_like_to_do",
-      "translation": "Did you like your first lesson? What would you like to do?\n\na) move up to a more difficult level\nb) stay in this level",
-      "translation_type": "lesson",
-      "created_at": "2020-02-27T01:21:17Z",
-      "updated_at": "2020-02-27T01:22:18Z",
-      "language": "en"
-    },
-    {
-      "id": 2007,
       "label": "self_eval",
       "translation": "En una escala del 1 al 5, ¿cómo te sentiste con esta lección?\n5 = 🤩 me encantó\n4 = 😁 me gustó\n3 = 😕 me gustó más o menos\n2 = 😟 no me gustó\n1 = 🤬 La odie",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 2857,
-      "label": "until",
-      "translation": "hasta",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T01:19:46Z",
-      "updated_at": "2020-02-24T01:19:46Z",
-      "language": "es"
-    },
-    {
-      "id": 2895,
-      "label": "your",
-      "translation": "your",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T05:19:28Z",
-      "updated_at": "2020-02-24T05:19:28Z",
-      "language": "en"
-    },
-    {
-      "id": 2853,
-      "label": "is_not_the_same_as",
-      "translation": "is not the same as",
-      "translation_type": "lesson",
-      "created_at": "2020-02-24T00:56:27Z",
-      "updated_at": "2020-02-24T00:56:27Z",
-      "language": "en"
-    },
-    {
-      "id": 2854,
-      "label": "is_not_the_same_as",
-      "translation": "n'est pas la même chose que",
-      "translation_type": "lesson",
-      "created_at": "2020-02-24T00:57:04Z",
-      "updated_at": "2020-02-24T00:57:04Z",
-      "language": "fr"
-    },
-    {
-      "id": 2840,
-      "label": "which_phrase_is_correct",
-      "translation": "🤓Which phrase is correct?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T20:18:52Z",
-      "updated_at": "2020-02-24T03:08:07Z",
-      "language": "en"
-    },
-    {
-      "id": 2904,
-      "label": "allergic",
-      "translation": "allergic",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:25:46Z",
-      "updated_at": "2020-02-29T21:25:46Z",
-      "language": "en"
-    },
-    {
-      "id": 2910,
-      "label": "hand_mixer",
-      "translation": "hand mixer",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:15Z",
-      "updated_at": "2020-02-29T21:26:15Z",
-      "language": "en"
-    },
-    {
-      "id": 2917,
-      "label": "thick",
-      "translation": "thick",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:50Z",
-      "updated_at": "2020-02-29T21:26:50Z",
-      "language": "en"
-    },
-    {
-      "id": 2919,
-      "label": "clipboard",
-      "translation": "clipboard",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:01Z",
-      "updated_at": "2020-02-29T21:27:01Z",
-      "language": "en"
-    },
-    {
-      "id": 2925,
-      "label": "really",
-      "translation": "really",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:31Z",
-      "updated_at": "2020-02-29T21:27:31Z",
-      "language": "en"
-    },
-    {
-      "id": 2951,
-      "label": "stand_mixer",
-      "translation": "mélangeur permanent\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:33:38Z",
-      "updated_at": "2020-02-29T21:33:38Z",
-      "language": "fr"
-    },
-    {
-      "id": 2962,
-      "label": "scale",
-      "translation": "balanza",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:39:25Z",
-      "updated_at": "2020-02-29T21:39:25Z",
-      "language": "es"
-    },
-    {
-      "id": 2965,
-      "label": "clipboard",
-      "translation": "tabla con clip",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:40:36Z",
-      "updated_at": "2020-02-29T21:40:36Z",
-      "language": "es"
-    },
-    {
-      "id": 2971,
-      "label": "printer",
-      "translation": "imprimante",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:41:44Z",
-      "updated_at": "2020-02-29T21:41:44Z",
-      "language": "fr"
-    },
-    {
-      "id": 2973,
-      "label": "receipt_paper",
-      "translation": "papier de reçu\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:42:08Z",
-      "updated_at": "2020-02-29T21:42:08Z",
-      "language": "fr"
-    },
-    {
-      "id": 2974,
-      "label": "efficient",
-      "translation": "eficiente",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:42:23Z",
-      "updated_at": "2020-02-29T21:42:23Z",
-      "language": "es"
-    },
-    {
-      "id": 2978,
-      "label": "messy",
-      "translation": "desordenado",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:43:28Z",
-      "updated_at": "2020-02-29T21:43:28Z",
-      "language": "es"
-    },
-    {
-      "id": 2980,
-      "label": "overcooked",
-      "translation": "recocido",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:43:55Z",
-      "updated_at": "2020-02-29T21:43:55Z",
-      "language": "es"
-    },
-    {
-      "id": 2983,
-      "label": "burnt",
-      "translation": "brûlé",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:44:36Z",
-      "updated_at": "2020-02-29T21:44:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 2985,
-      "label": "yet",
-      "translation": "encore",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:45:00Z",
-      "updated_at": "2020-02-29T21:45:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2988,
-      "label": "behind",
-      "translation": "detrás de",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:45:57Z",
-      "updated_at": "2020-02-29T21:45:57Z",
-      "language": "es"
-    },
-    {
-      "id": 2995,
-      "label": "raise",
-      "translation": "raise",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:48:36Z",
-      "updated_at": "2020-02-29T21:48:36Z",
-      "language": "en"
-    },
-    {
-      "id": 2996,
-      "label": "salary",
-      "translation": "salary",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:48:40Z",
-      "updated_at": "2020-02-29T21:48:40Z",
-      "language": "en"
-    },
-    {
-      "id": 2347,
-      "label": "right",
-      "translation": "right",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:31:44Z",
-      "updated_at": "2020-02-23T05:31:44Z",
-      "language": "en"
-    },
-    {
-      "id": 2344,
-      "label": "black_and_white",
-      "translation": "black and white",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:31:02Z",
-      "updated_at": "2020-02-23T05:31:02Z",
-      "language": "en"
-    },
-    {
-      "id": 2343,
-      "label": "white",
-      "translation": "blanc",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:30:45Z",
-      "updated_at": "2020-02-23T05:30:45Z",
-      "language": "fr"
-    },
-    {
-      "id": 2342,
-      "label": "white",
-      "translation": "blanco",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:30:40Z",
-      "updated_at": "2020-02-23T05:30:40Z",
-      "language": "es"
-    },
-    {
-      "id": 2341,
-      "label": "white",
-      "translation": "white",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:30:28Z",
-      "updated_at": "2020-02-23T05:30:28Z",
-      "language": "en"
-    },
-    {
-      "id": 2338,
-      "label": "uniform",
-      "translation": "uniform",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:29:55Z",
-      "updated_at": "2020-02-23T05:29:55Z",
-      "language": "en"
-    },
-    {
-      "id": 2328,
-      "label": "black",
-      "translation": "noir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:27:31Z",
-      "updated_at": "2020-02-23T05:27:31Z",
-      "language": "fr"
-    },
-    {
-      "id": 2325,
-      "label": "stir",
-      "translation": "remuer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:27:03Z",
-      "updated_at": "2020-02-23T05:27:03Z",
-      "language": "fr"
-    },
-    {
-      "id": 2280,
-      "label": "important",
-      "translation": "importante",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:17:38Z",
-      "updated_at": "2020-02-23T05:17:38Z",
-      "language": "fr"
-    },
-    {
-      "id": 2226,
-      "label": "thursday",
-      "translation": "Jeudi",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T03:08:50Z",
-      "updated_at": "2020-02-23T03:08:50Z",
-      "language": "fr"
-    },
-    {
-      "id": 2224,
-      "label": "thursday",
-      "translation": "Thursday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T03:08:28Z",
-      "updated_at": "2020-02-23T03:08:28Z",
-      "language": "en"
-    },
-    {
-      "id": 2626,
-      "label": "monday",
-      "translation": "Monday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2991,
-      "label": "immediately",
-      "translation": "immédiatement",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:46:34Z",
-      "updated_at": "2020-02-29T21:46:34Z",
-      "language": "fr"
-    },
-    {
-      "id": 2780,
-      "label": "monday",
-      "translation": "Lundi",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 2627,
-      "label": "friday",
-      "translation": "Friday",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T01:00:00Z",
-      "updated_at": "2020-02-23T01:00:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2992,
-      "label": "ill_be_right_back",
-      "translation": "Ahora vuelvo.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:46:51Z",
-      "updated_at": "2020-02-29T21:47:04Z",
-      "language": "es"
-    },
-    {
-      "id": 2993,
-      "label": "ill_be_right_back",
-      "translation": "Je reviens tout de suite.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:46:58Z",
-      "updated_at": "2020-02-29T21:47:12Z",
-      "language": "fr"
-    },
-    {
-      "id": 2899,
-      "label": "did_you_like_your_first_lesson_what_would_you_like_to_do",
-      "translation": "¿Te gustó tu primera lección? ¿Qué te gustaría hacer?\n\na) bajar a un nivel más difícil\nb) permanecer en este nivel",
-      "translation_type": "lesson",
-      "created_at": "2020-02-27T01:21:40Z",
-      "updated_at": "2020-02-27T01:22:27Z",
-      "language": "es"
-    },
-    {
-      "id": 2896,
-      "label": "your",
-      "translation": "su \/ sus",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T05:19:44Z",
-      "updated_at": "2020-02-24T05:19:44Z",
-      "language": "es"
-    },
-    {
-      "id": 2362,
-      "label": "store",
-      "translation": "store",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:03:18Z",
-      "updated_at": "2020-02-23T06:03:18Z",
-      "language": "en"
-    },
-    {
-      "id": 2363,
-      "label": "store",
-      "translation": "guardar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:03:24Z",
-      "updated_at": "2020-02-23T06:03:24Z",
-      "language": "es"
-    },
-    {
-      "id": 2364,
-      "label": "store",
-      "translation": "sauvegarder",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:03:32Z",
-      "updated_at": "2020-02-23T06:03:32Z",
-      "language": "fr"
-    },
-    {
-      "id": 2359,
-      "label": "take_a_break",
-      "translation": "take a break",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:00:53Z",
-      "updated_at": "2020-02-23T06:00:53Z",
-      "language": "en"
-    },
-    {
-      "id": 2361,
-      "label": "take_a_break",
-      "translation": "se reposer",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:01:38Z",
-      "updated_at": "2020-02-23T06:01:38Z",
-      "language": "fr"
-    },
-    {
-      "id": 2360,
-      "label": "take_a_break",
-      "translation": "descanser",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:01:10Z",
-      "updated_at": "2020-02-23T06:01:53Z",
-      "language": "es"
-    },
-    {
-      "id": 2356,
-      "label": "order",
-      "translation": "order",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:00:01Z",
-      "updated_at": "2020-02-23T06:00:01Z",
-      "language": "en"
-    },
-    {
-      "id": 2357,
-      "label": "order",
-      "translation": "ordenar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:00:04Z",
-      "updated_at": "2020-02-23T06:00:04Z",
-      "language": "es"
-    },
-    {
-      "id": 2358,
-      "label": "order",
-      "translation": "ordonner",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:00:17Z",
-      "updated_at": "2020-02-23T06:00:17Z",
-      "language": "fr"
-    },
-    {
-      "id": 2353,
-      "label": "clean_out",
-      "translation": "clean out",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:59:03Z",
-      "updated_at": "2020-02-23T05:59:03Z",
-      "language": "en"
-    },
-    {
-      "id": 2354,
-      "label": "clean_out",
-      "translation": "vaciar",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:59:06Z",
-      "updated_at": "2020-02-23T05:59:06Z",
-      "language": "es"
-    },
-    {
-      "id": 2355,
-      "label": "clean_out",
-      "translation": "vide",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T05:59:22Z",
-      "updated_at": "2020-02-23T05:59:22Z",
-      "language": "fr"
-    },
-    {
-      "id": 2365,
-      "label": "have_to",
-      "translation": "have to",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:14:21Z",
-      "updated_at": "2020-02-23T06:14:21Z",
-      "language": "en"
-    },
-    {
-      "id": 2366,
-      "label": "have_to",
-      "translation": "tener que",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:14:25Z",
-      "updated_at": "2020-02-23T06:14:25Z",
-      "language": "es"
-    },
-    {
-      "id": 2367,
-      "label": "have_to",
-      "translation": "devoir",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T06:14:36Z",
-      "updated_at": "2020-02-23T06:14:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 2893,
-      "label": "i_need",
-      "translation": "Yo necesito",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T02:58:15Z",
-      "updated_at": "2020-02-24T02:58:15Z",
-      "language": "es"
-    },
-    {
-      "id": 2841,
-      "label": "which_phrase_is_correct",
-      "translation": "🤓¿Cuál frase es correcta?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T20:19:12Z",
-      "updated_at": "2020-02-24T03:08:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2855,
-      "label": "is_not_the_same_as",
-      "translation": "no es lo mismo que",
-      "translation_type": "lesson",
-      "created_at": "2020-02-24T00:57:17Z",
-      "updated_at": "2020-02-24T00:57:17Z",
-      "language": "es"
-    },
-    {
-      "id": 2905,
-      "label": "wheat_gluten",
-      "translation": "wheat gluten",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:25:52Z",
-      "updated_at": "2020-02-29T21:25:52Z",
-      "language": "en"
-    },
-    {
-      "id": 2227,
-      "label": "audio_instructions",
-      "translation": "_Use WhatsApp to send your voice!_ 🎤",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T03:09:52Z",
-      "updated_at": "2020-02-23T03:10:32Z",
-      "language": "en"
-    },
-    {
-      "id": 2230,
-      "label": "audio_instructions_full",
-      "translation": "_Use WhatsApp to send your voice!_ 🎤\n\n1. Press and hold the microphone ↘️\n2. Start speaking.\n3. When finished speaking, remove your finger from the microphone.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T03:11:30Z",
-      "updated_at": "2020-02-23T03:32:09Z",
-      "language": "en"
-    },
-    {
-      "id": 2906,
-      "label": "nuts",
-      "translation": "nuts",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:25:57Z",
-      "updated_at": "2020-02-29T21:25:57Z",
-      "language": "en"
-    },
-    {
-      "id": 2909,
-      "label": "dough",
-      "translation": "dough",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:07Z",
-      "updated_at": "2020-02-29T21:26:07Z",
-      "language": "en"
-    },
-    {
-      "id": 2914,
-      "label": "rolling_pin",
-      "translation": "rolling pin",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:35Z",
-      "updated_at": "2020-02-29T21:26:35Z",
-      "language": "en"
-    },
-    {
-      "id": 2921,
-      "label": "computer",
-      "translation": "computer",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:13Z",
-      "updated_at": "2020-02-29T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2922,
-      "label": "printer",
-      "translation": "printer",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:17Z",
-      "updated_at": "2020-02-29T21:27:17Z",
-      "language": "en"
-    },
-    {
-      "id": 2923,
-      "label": "receipt_paper",
-      "translation": "receipt paper",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:22Z",
-      "updated_at": "2020-02-29T21:27:22Z",
-      "language": "en"
-    },
-    {
-      "id": 2924,
-      "label": "efficient",
-      "translation": "efficient",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:26Z",
-      "updated_at": "2020-02-29T21:27:26Z",
-      "language": "en"
-    },
-    {
-      "id": 2926,
-      "label": "messy",
-      "translation": "messy",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:37Z",
-      "updated_at": "2020-02-29T21:27:37Z",
-      "language": "en"
-    },
-    {
-      "id": 2928,
-      "label": "burnt",
-      "translation": "burnt",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:45Z",
-      "updated_at": "2020-02-29T21:27:45Z",
-      "language": "en"
-    },
-    {
-      "id": 2930,
-      "label": "as_soon_as",
-      "translation": "as soon as",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:52Z",
-      "updated_at": "2020-02-29T21:27:52Z",
-      "language": "en"
-    },
-    {
-      "id": 2932,
-      "label": "immediately",
-      "translation": "immediately",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:28:00Z",
-      "updated_at": "2020-02-29T21:28:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2933,
-      "label": "ill_be_right_back",
-      "translation": "I'll be right back.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:28:07Z",
-      "updated_at": "2020-02-29T21:28:07Z",
-      "language": "en"
-    },
-    {
-      "id": 2935,
-      "label": "allergic",
-      "translation": "allergique",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:28:57Z",
-      "updated_at": "2020-02-29T21:28:57Z",
-      "language": "fr"
-    },
-    {
-      "id": 2936,
-      "label": "wheat_gluten",
-      "translation": "gluten de trigo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:29:25Z",
-      "updated_at": "2020-02-29T21:29:25Z",
-      "language": "es"
-    },
-    {
-      "id": 2938,
-      "label": "nuts",
-      "translation": "nueces",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:29:51Z",
-      "updated_at": "2020-02-29T21:29:51Z",
-      "language": "es"
-    },
-    {
-      "id": 2945,
-      "label": "dough",
-      "translation": "masse",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:32:02Z",
-      "updated_at": "2020-02-29T21:32:02Z",
-      "language": "fr"
-    },
-    {
-      "id": 2949,
-      "label": "mixing_bowl",
-      "translation": "bol",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:33:07Z",
-      "updated_at": "2020-02-29T21:33:07Z",
-      "language": "fr"
-    },
-    {
-      "id": 2954,
-      "label": "rolling_pin",
-      "translation": "rodillo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:37:10Z",
-      "updated_at": "2020-02-29T21:37:10Z",
-      "language": "es"
-    },
-    {
-      "id": 2961,
-      "label": "thick",
-      "translation": "épais",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:38:49Z",
-      "updated_at": "2020-02-29T21:38:49Z",
-      "language": "fr"
-    },
-    {
-      "id": 2966,
-      "label": "tape",
-      "translation": "cinta",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:40:52Z",
-      "updated_at": "2020-02-29T21:40:52Z",
-      "language": "es"
-    },
-    {
-      "id": 2967,
-      "label": "tape",
-      "translation": "bande",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:40:58Z",
-      "updated_at": "2020-02-29T21:40:58Z",
-      "language": "fr"
-    },
-    {
-      "id": 2968,
-      "label": "computer",
-      "translation": "computadora",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:41:12Z",
-      "updated_at": "2020-02-29T21:41:12Z",
-      "language": "es"
-    },
-    {
-      "id": 2969,
-      "label": "computer",
-      "translation": "ordinateur",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:41:21Z",
-      "updated_at": "2020-02-29T21:41:21Z",
-      "language": "fr"
-    },
-    {
-      "id": 2970,
-      "label": "printer",
-      "translation": "impresora",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:41:37Z",
-      "updated_at": "2020-02-29T21:41:37Z",
-      "language": "es"
-    },
-    {
-      "id": 2975,
-      "label": "efficient",
-      "translation": "efficace",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:42:32Z",
-      "updated_at": "2020-02-29T21:42:32Z",
-      "language": "fr"
-    },
-    {
-      "id": 2977,
-      "label": "really",
-      "translation": "très",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:43:12Z",
-      "updated_at": "2020-02-29T21:43:12Z",
-      "language": "fr"
-    },
-    {
-      "id": 2982,
-      "label": "burnt",
-      "translation": "quemado",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:44:27Z",
-      "updated_at": "2020-02-29T21:44:27Z",
-      "language": "es"
-    },
-    {
-      "id": 2984,
-      "label": "yet",
-      "translation": "todavía",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:44:52Z",
-      "updated_at": "2020-02-29T21:44:52Z",
-      "language": "es"
-    },
-    {
-      "id": 2989,
-      "label": "behind",
-      "translation": "derrière",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:46:03Z",
-      "updated_at": "2020-02-29T21:46:03Z",
-      "language": "fr"
-    },
-    {
-      "id": 2997,
-      "label": "hourly",
-      "translation": "hourly",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:48:45Z",
-      "updated_at": "2020-02-29T21:48:45Z",
-      "language": "en"
-    },
-    {
-      "id": 3001,
-      "label": "short_term",
-      "translation": "short-term",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:04Z",
-      "updated_at": "2020-02-29T21:49:04Z",
-      "language": "en"
-    },
-    {
-      "id": 3002,
-      "label": "on_leave",
-      "translation": "on leave",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:09Z",
-      "updated_at": "2020-02-29T21:49:09Z",
-      "language": "en"
-    },
-    {
-      "id": 3005,
-      "label": "because",
-      "translation": "because",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:33Z",
-      "updated_at": "2020-02-29T21:49:33Z",
-      "language": "en"
-    },
-    {
-      "id": 3006,
-      "label": "so",
-      "translation": "so",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:36Z",
-      "updated_at": "2020-02-29T21:49:36Z",
-      "language": "en"
-    },
-    {
-      "id": 3008,
-      "label": "unfortunately",
-      "translation": "unfortunately",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:45Z",
-      "updated_at": "2020-02-29T21:49:45Z",
-      "language": "en"
-    },
-    {
-      "id": 3009,
-      "label": "usually",
-      "translation": "usually",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:50Z",
-      "updated_at": "2020-02-29T21:49:50Z",
-      "language": "en"
-    },
-    {
-      "id": 3010,
-      "label": "promotion",
-      "translation": "promoción",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:50:21Z",
-      "updated_at": "2020-02-29T21:50:21Z",
-      "language": "es"
-    },
-    {
-      "id": 3011,
-      "label": "promotion",
-      "translation": "promotion",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:50:27Z",
-      "updated_at": "2020-02-29T21:50:27Z",
-      "language": "fr"
-    },
-    {
-      "id": 3012,
-      "label": "raise",
-      "translation": "aumento de sueldo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:50:43Z",
-      "updated_at": "2020-02-29T21:50:43Z",
-      "language": "es"
-    },
-    {
-      "id": 3013,
-      "label": "raise",
-      "translation": "augmentation de salaire\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:50:53Z",
-      "updated_at": "2020-02-29T21:50:53Z",
-      "language": "fr"
-    },
-    {
-      "id": 3018,
-      "label": "mandatory",
-      "translation": "obligatorio",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:52:34Z",
-      "updated_at": "2020-02-29T21:52:34Z",
-      "language": "es"
-    },
-    {
-      "id": 3019,
-      "label": "mandatory",
-      "translation": "obligatoire",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:52:41Z",
-      "updated_at": "2020-02-29T21:52:41Z",
-      "language": "fr"
-    },
-    {
-      "id": 3045,
-      "label": "gold",
-      "translation": "gold",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:05Z",
-      "updated_at": "2020-02-29T22:01:05Z",
-      "language": "en"
-    },
-    {
-      "id": 2848,
-      "label": "lets_practice_write_the_word",
-      "translation": "Let's practice! Write the word",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T21:58:52Z",
-      "updated_at": "2020-02-23T21:58:52Z",
-      "language": "en"
-    },
-    {
-      "id": 3047,
-      "label": "grey",
-      "translation": "grey",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:10Z",
-      "updated_at": "2020-02-29T22:01:10Z",
-      "language": "en"
-    },
-    {
-      "id": 2900,
-      "label": "did_you_like_your_first_lesson_what_would_you_like_to_do",
-      "translation": "Vous avez aimé votre première leçon? Qu'est-ce que tu aimerais faire?\n\na) plus bas à un niveau plus difficile\nb) rester à ce niveau",
-      "translation_type": "lesson",
-      "created_at": "2020-02-27T01:23:54Z",
-      "updated_at": "2020-02-27T01:23:54Z",
-      "language": "fr"
-    },
-    {
-      "id": 2856,
-      "label": "until",
-      "translation": "until",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T01:19:38Z",
-      "updated_at": "2020-02-24T01:19:38Z",
-      "language": "en"
-    },
-    {
-      "id": 2858,
-      "label": "until",
-      "translation": "jusqu'à",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T01:19:59Z",
-      "updated_at": "2020-02-24T01:19:59Z",
-      "language": "fr"
-    },
-    {
-      "id": 2897,
-      "label": "your",
-      "translation": "son \/ sa",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T05:19:59Z",
-      "updated_at": "2020-02-24T05:19:59Z",
-      "language": "fr"
-    },
-    {
-      "id": 2833,
-      "label": "newspaper",
-      "translation": "newspaper",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T07:35:26Z",
-      "updated_at": "2020-02-23T07:35:26Z",
-      "language": "en"
-    },
-    {
-      "id": 2835,
-      "label": "newspaper",
-      "translation": "journal",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T07:35:58Z",
-      "updated_at": "2020-02-23T07:35:58Z",
-      "language": "fr"
-    },
-    {
-      "id": 2894,
-      "label": "i_need",
-      "translation": "J'ai besoin",
-      "translation_type": "vocab",
-      "created_at": "2020-02-24T02:58:29Z",
-      "updated_at": "2020-02-24T02:58:29Z",
-      "language": "fr"
-    },
-    {
-      "id": 3048,
-      "label": "sick",
-      "translation": "sick",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:12Z",
-      "updated_at": "2020-02-29T22:01:12Z",
-      "language": "en"
-    },
-    {
-      "id": 3032,
-      "label": "whether",
-      "translation": "qu'il s'agisse",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:58:47Z",
-      "updated_at": "2020-02-29T21:58:47Z",
-      "language": "fr"
-    },
-    {
-      "id": 1878,
-      "label": "fill_in_the_phrase_with_the_correct_word",
-      "translation": "👽Rellena la frase con la palabra correcta.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 2851,
-      "label": "practice_speaking_fill_in_the_sentence_then_send_me_audio",
-      "translation": "🗣Entraînez-vous à l'orale! Remplissez la phrase. Envoyez-moi ensuite l'audio.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T22:01:47Z",
-      "updated_at": "2020-02-23T22:02:22Z",
-      "language": "fr"
-    },
-    {
-      "id": 2216,
-      "label": "practice_speaking_say_the_word_below",
-      "translation": "🗣Practice speaking! Say the word below 3 times.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-23T20:05:24Z",
-      "language": "en"
-    },
-    {
-      "id": 2907,
-      "label": "dairy",
-      "translation": "dairy",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:00Z",
-      "updated_at": "2020-02-29T21:26:00Z",
-      "language": "en"
-    },
-    {
-      "id": 2920,
-      "label": "tape",
-      "translation": "tape",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:05Z",
-      "updated_at": "2020-02-29T21:27:05Z",
-      "language": "en"
-    },
-    {
-      "id": 2929,
-      "label": "yet",
-      "translation": "yet",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:49Z",
-      "updated_at": "2020-02-29T21:27:49Z",
-      "language": "en"
-    },
-    {
-      "id": 2931,
-      "label": "behind",
-      "translation": "behind",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:56Z",
-      "updated_at": "2020-02-29T21:27:56Z",
-      "language": "en"
-    },
-    {
-      "id": 2950,
-      "label": "stand_mixer",
-      "translation": "mezclador permanente\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:33:30Z",
-      "updated_at": "2020-02-29T21:33:30Z",
-      "language": "es"
-    },
-    {
-      "id": 2994,
-      "label": "promotion",
-      "translation": "promotion",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:48:33Z",
-      "updated_at": "2020-02-29T21:48:33Z",
-      "language": "en"
-    },
-    {
-      "id": 2998,
-      "label": "mandatory",
-      "translation": "mandatory",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:48:49Z",
-      "updated_at": "2020-02-29T21:48:49Z",
-      "language": "en"
-    },
-    {
-      "id": 2999,
-      "label": "previously",
-      "translation": "previously",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:48:54Z",
-      "updated_at": "2020-02-29T21:48:54Z",
-      "language": "en"
-    },
-    {
-      "id": 3003,
-      "label": "tenure",
-      "translation": "tenure",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:20Z",
-      "updated_at": "2020-02-29T21:49:20Z",
-      "language": "en"
-    },
-    {
-      "id": 3004,
-      "label": "whether",
-      "translation": "whether",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:23Z",
-      "updated_at": "2020-02-29T21:49:23Z",
-      "language": "en"
-    },
-    {
-      "id": 3014,
-      "label": "salary",
-      "translation": "sueldo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:51:15Z",
-      "updated_at": "2020-02-29T21:51:15Z",
-      "language": "es"
-    },
-    {
-      "id": 3015,
-      "label": "salary",
-      "translation": "salaire",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:51:25Z",
-      "updated_at": "2020-02-29T21:51:25Z",
-      "language": "fr"
-    },
-    {
-      "id": 3016,
-      "label": "hourly",
-      "translation": "por hora",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:52:10Z",
-      "updated_at": "2020-02-29T21:52:10Z",
-      "language": "es"
-    },
-    {
-      "id": 3017,
-      "label": "hourly",
-      "translation": "par heure\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:52:20Z",
-      "updated_at": "2020-02-29T21:52:20Z",
-      "language": "fr"
-    },
-    {
-      "id": 3020,
-      "label": "previously",
-      "translation": "antes",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:53:13Z",
-      "updated_at": "2020-02-29T21:53:13Z",
-      "language": "es"
-    },
-    {
-      "id": 3021,
-      "label": "previously",
-      "translation": "avant",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:53:20Z",
-      "updated_at": "2020-02-29T21:53:20Z",
-      "language": "fr"
-    },
-    {
-      "id": 3000,
-      "label": "long_term",
-      "translation": "long-term",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:49:00Z",
-      "updated_at": "2020-02-29T21:53:26Z",
-      "language": "en"
-    },
-    {
-      "id": 3022,
-      "label": "long_term",
-      "translation": "de larga duración",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:54:33Z",
-      "updated_at": "2020-02-29T21:54:33Z",
-      "language": "es"
-    },
-    {
-      "id": 3023,
-      "label": "long_term",
-      "translation": "longue durée\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:54:39Z",
-      "updated_at": "2020-02-29T21:54:39Z",
-      "language": "fr"
-    },
-    {
-      "id": 3024,
-      "label": "temporary",
-      "translation": "temporary",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:54:48Z",
-      "updated_at": "2020-02-29T21:54:48Z",
-      "language": "en"
-    },
-    {
-      "id": 3025,
-      "label": "temporary",
-      "translation": "temporal",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:55:16Z",
-      "updated_at": "2020-02-29T21:55:16Z",
-      "language": "es"
-    },
-    {
-      "id": 3026,
-      "label": "temporary",
-      "translation": "temporaire",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:55:24Z",
-      "updated_at": "2020-02-29T21:55:24Z",
-      "language": "fr"
-    },
-    {
-      "id": 3027,
-      "label": "on_leave",
-      "translation": "en licencia\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:56:10Z",
-      "updated_at": "2020-02-29T21:56:10Z",
-      "language": "es"
-    },
-    {
-      "id": 3028,
-      "label": "on_leave",
-      "translation": "en congé\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:56:15Z",
-      "updated_at": "2020-02-29T21:56:15Z",
-      "language": "fr"
-    },
-    {
-      "id": 3029,
-      "label": "tenure",
-      "translation": "ocupación",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:58:11Z",
-      "updated_at": "2020-02-29T21:58:11Z",
-      "language": "es"
-    },
-    {
-      "id": 3030,
-      "label": "tenure",
-      "translation": "occupation\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:58:16Z",
-      "updated_at": "2020-02-29T21:58:16Z",
-      "language": "fr"
-    },
-    {
-      "id": 3031,
-      "label": "whether",
-      "translation": "si",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:58:30Z",
-      "updated_at": "2020-02-29T21:58:30Z",
-      "language": "es"
-    },
-    {
-      "id": 3033,
-      "label": "because",
-      "translation": "porque",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:58:53Z",
-      "updated_at": "2020-02-29T21:58:53Z",
-      "language": "es"
-    },
-    {
-      "id": 3034,
-      "label": "because",
-      "translation": "parce que\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:59:04Z",
-      "updated_at": "2020-02-29T21:59:04Z",
-      "language": "fr"
-    },
-    {
-      "id": 3036,
-      "label": "so",
-      "translation": "así que",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:59:38Z",
-      "updated_at": "2020-02-29T21:59:38Z",
-      "language": "es"
-    },
-    {
-      "id": 3037,
-      "label": "so",
-      "translation": "alors",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:59:45Z",
-      "updated_at": "2020-02-29T21:59:45Z",
-      "language": "fr"
-    },
-    {
-      "id": 3038,
-      "label": "unfortunately",
-      "translation": "desafortunadamente",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:00:00Z",
-      "updated_at": "2020-02-29T22:00:00Z",
-      "language": "es"
-    },
-    {
-      "id": 3039,
-      "label": "unfortunately",
-      "translation": "malheureusement",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:00:09Z",
-      "updated_at": "2020-02-29T22:00:09Z",
-      "language": "fr"
-    },
-    {
-      "id": 3040,
-      "label": "usually",
-      "translation": "por lo general",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:00:27Z",
-      "updated_at": "2020-02-29T22:00:27Z",
-      "language": "es"
-    },
-    {
-      "id": 3041,
-      "label": "usually",
-      "translation": "habituellement",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:00:40Z",
-      "updated_at": "2020-02-29T22:00:40Z",
-      "language": "fr"
-    },
-    {
-      "id": 3042,
-      "label": "usually",
-      "translation": "habituellement",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:00:40Z",
-      "updated_at": "2020-02-29T22:00:40Z",
-      "language": "fr"
-    },
-    {
-      "id": 3043,
-      "label": "silver",
-      "translation": "silver",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:00:59Z",
-      "updated_at": "2020-02-29T22:00:59Z",
-      "language": "en"
-    },
-    {
-      "id": 3044,
-      "label": "copper",
-      "translation": "copper",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:02Z",
-      "updated_at": "2020-02-29T22:01:02Z",
-      "language": "en"
-    },
-    {
-      "id": 3049,
-      "label": "cant",
-      "translation": "can't",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:14Z",
-      "updated_at": "2020-02-29T22:01:14Z",
-      "language": "en"
-    },
-    {
-      "id": 3050,
-      "label": "come",
-      "translation": "come",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:16Z",
-      "updated_at": "2020-02-29T22:01:16Z",
-      "language": "en"
-    },
-    {
-      "id": 3051,
-      "label": "feel",
-      "translation": "feel",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:18Z",
-      "updated_at": "2020-02-29T22:01:18Z",
-      "language": "en"
-    },
-    {
-      "id": 3052,
-      "label": "time_off",
-      "translation": "time off",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:20Z",
-      "updated_at": "2020-02-29T22:01:20Z",
-      "language": "en"
-    },
-    {
-      "id": 3053,
-      "label": "family",
-      "translation": "family",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:26Z",
-      "updated_at": "2020-02-29T22:01:26Z",
-      "language": "en"
-    },
-    {
-      "id": 3054,
-      "label": "husband",
-      "translation": "husband",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:28Z",
-      "updated_at": "2020-02-29T22:01:28Z",
-      "language": "en"
-    },
-    {
-      "id": 3055,
-      "label": "son",
-      "translation": "son",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:31Z",
-      "updated_at": "2020-02-29T22:01:31Z",
-      "language": "en"
-    },
-    {
-      "id": 3056,
-      "label": "daughter",
-      "translation": "daughter",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:01:33Z",
-      "updated_at": "2020-02-29T22:01:33Z",
-      "language": "en"
-    },
-    {
-      "id": 3057,
-      "label": "silver",
-      "translation": "plateado",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:02:16Z",
-      "updated_at": "2020-02-29T22:02:16Z",
-      "language": "es"
-    },
-    {
-      "id": 3058,
-      "label": "silver",
-      "translation": "plaqué argent\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:02:22Z",
-      "updated_at": "2020-02-29T22:02:22Z",
-      "language": "fr"
-    },
-    {
-      "id": 3059,
-      "label": "copper",
-      "translation": "cobrizo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:02:49Z",
-      "updated_at": "2020-02-29T22:02:49Z",
-      "language": "es"
-    },
-    {
-      "id": 3060,
-      "label": "copper",
-      "translation": "cuivré\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:02:57Z",
-      "updated_at": "2020-02-29T22:02:57Z",
-      "language": "fr"
-    },
-    {
-      "id": 3061,
-      "label": "gold",
-      "translation": "el color oro",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:03:13Z",
-      "updated_at": "2020-02-29T22:03:13Z",
-      "language": "es"
-    },
-    {
-      "id": 3062,
-      "label": "gold",
-      "translation": "la couleur or\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:03:19Z",
-      "updated_at": "2020-02-29T22:03:19Z",
-      "language": "fr"
-    },
-    {
-      "id": 3063,
-      "label": "grey",
-      "translation": "gris",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:03:57Z",
-      "updated_at": "2020-02-29T22:03:57Z",
-      "language": "es"
-    },
-    {
-      "id": 3064,
-      "label": "grey",
-      "translation": "gris",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:04:05Z",
-      "updated_at": "2020-02-29T22:04:05Z",
-      "language": "fr"
-    },
-    {
-      "id": 3065,
-      "label": "sick",
-      "translation": "enfermo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:04:27Z",
-      "updated_at": "2020-02-29T22:04:27Z",
-      "language": "es"
-    },
-    {
-      "id": 3066,
-      "label": "sick",
-      "translation": "malade",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:04:34Z",
-      "updated_at": "2020-02-29T22:04:34Z",
-      "language": "fr"
-    },
-    {
-      "id": 3067,
-      "label": "cant",
-      "translation": "no puedo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:04:55Z",
-      "updated_at": "2020-02-29T22:04:55Z",
-      "language": "es"
-    },
-    {
-      "id": 3068,
-      "label": "cant",
-      "translation": "je ne peux pas\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:05:07Z",
-      "updated_at": "2020-02-29T22:05:07Z",
-      "language": "fr"
-    },
-    {
-      "id": 3069,
-      "label": "come",
-      "translation": "llegar",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:05:22Z",
-      "updated_at": "2020-02-29T22:05:22Z",
-      "language": "es"
-    },
-    {
-      "id": 3070,
-      "label": "come",
-      "translation": "arriver",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:05:30Z",
-      "updated_at": "2020-02-29T22:05:30Z",
-      "language": "fr"
-    },
-    {
-      "id": 3071,
-      "label": "feel",
-      "translation": "sentir",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:05:55Z",
-      "updated_at": "2020-02-29T22:05:55Z",
-      "language": "es"
-    },
-    {
-      "id": 3072,
-      "label": "feel",
-      "translation": "sentir",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:06:04Z",
-      "updated_at": "2020-02-29T22:06:04Z",
-      "language": "fr"
-    },
-    {
-      "id": 3073,
-      "label": "time_off",
-      "translation": "tiempo libre",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:06:36Z",
-      "updated_at": "2020-02-29T22:06:36Z",
-      "language": "es"
-    },
-    {
-      "id": 3074,
-      "label": "time_off",
-      "translation": "temps libre\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:06:45Z",
-      "updated_at": "2020-02-29T22:06:45Z",
-      "language": "fr"
-    },
-    {
-      "id": 3075,
-      "label": "family",
-      "translation": "familia",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:06:53Z",
-      "updated_at": "2020-02-29T22:06:53Z",
-      "language": "es"
-    },
-    {
-      "id": 3076,
-      "label": "family",
-      "translation": "famille",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:07:03Z",
-      "updated_at": "2020-02-29T22:07:03Z",
-      "language": "fr"
-    },
-    {
-      "id": 3078,
-      "label": "husband",
-      "translation": "époux",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:07:30Z",
-      "updated_at": "2020-02-29T22:07:30Z",
-      "language": "fr"
-    },
-    {
-      "id": 3081,
-      "label": "daughter",
-      "translation": "hija",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:08:08Z",
-      "updated_at": "2020-02-29T22:08:08Z",
-      "language": "es"
-    },
-    {
-      "id": 2927,
-      "label": "overcooked",
-      "translation": "overcooked",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:27:42Z",
-      "updated_at": "2020-02-29T21:27:42Z",
-      "language": "en"
-    },
-    {
-      "id": 2934,
-      "label": "allergic",
-      "translation": "alérgico",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:28:30Z",
-      "updated_at": "2020-02-29T21:28:40Z",
-      "language": "es"
-    },
-    {
-      "id": 2940,
-      "label": "dairy",
-      "translation": "lácteos \n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:30:47Z",
-      "updated_at": "2020-02-29T21:30:47Z",
-      "language": "es"
-    },
-    {
-      "id": 2941,
-      "label": "dairy",
-      "translation": "laiterie",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:30:53Z",
-      "updated_at": "2020-02-29T21:30:53Z",
-      "language": "fr"
-    },
-    {
-      "id": 2850,
-      "label": "lets_practice_write_the_word",
-      "translation": "Pratiquons! Écrivez le mot",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T21:59:46Z",
-      "updated_at": "2020-02-23T21:59:46Z",
-      "language": "fr"
-    },
-    {
-      "id": 2859,
-      "label": "ashamed",
-      "translation": "avergonzado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2860,
-      "label": "excited",
-      "translation": "emocionado",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2861,
-      "label": "unconscious",
-      "translation": "inconsciente",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2862,
-      "label": "shy",
-      "translation": "tímido",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2863,
-      "label": "cautious",
-      "translation": "cauteloso",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2864,
-      "label": "should",
-      "translation": "debería",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2865,
-      "label": "could",
-      "translation": "podría",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2866,
-      "label": "would_do",
-      "translation": "haría",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2867,
-      "label": "clumsy",
-      "translation": "torpe",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2868,
-      "label": "clean_tables",
-      "translation": "limpia mesas",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2869,
-      "label": "unless",
-      "translation": "a menos que",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "es"
-    },
-    {
-      "id": 2870,
-      "label": "ashamed",
-      "translation": "ashamed",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2871,
-      "label": "excited",
-      "translation": "excited",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2872,
-      "label": "unconscious",
-      "translation": "unconscious",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2873,
-      "label": "shy",
-      "translation": "shy",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2874,
-      "label": "cautious",
-      "translation": "cautious",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2875,
-      "label": "should",
-      "translation": "should",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2876,
-      "label": "could",
-      "translation": "could",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2877,
-      "label": "would_do",
-      "translation": "would do",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2878,
-      "label": "clumsy",
-      "translation": "clumsy",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2879,
-      "label": "clean_tables",
-      "translation": "clean tables",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2880,
-      "label": "unless",
-      "translation": "unless",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "en"
-    },
-    {
-      "id": 2881,
-      "label": "ashamed",
-      "translation": "honteux",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2882,
-      "label": "excited",
-      "translation": "excité",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2883,
-      "label": "unconscious",
-      "translation": "inconscient",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2884,
-      "label": "shy",
-      "translation": "timide",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2885,
-      "label": "cautious",
-      "translation": "prudent",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2886,
-      "label": "should",
-      "translation": "devrait",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2887,
-      "label": "could",
-      "translation": "pourrait",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2888,
-      "label": "would_do",
-      "translation": "ferait",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2889,
-      "label": "clumsy",
-      "translation": "maladroit",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2890,
-      "label": "clean_tables",
-      "translation": "tables propres",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2891,
-      "label": "unless",
-      "translation": "sauf si",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T21:27:13Z",
-      "updated_at": "2020-02-23T21:27:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 1941,
-      "label": "towel",
-      "translation": "trapo",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-24T03:01:31Z",
-      "language": "es"
-    },
-    {
-      "id": 2124,
-      "label": "towel",
-      "translation": "chiffon",
-      "translation_type": "vocab",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-24T03:01:53Z",
-      "language": "fr"
-    },
-    {
-      "id": 2943,
-      "label": "soy",
-      "translation": "soja",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:31:40Z",
-      "updated_at": "2020-02-29T21:31:40Z",
-      "language": "fr"
-    },
-    {
-      "id": 1825,
       "label": "text_done",
       "translation": "Got it 👍 text me the word *DONE* to finish.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 2008,
       "label": "text_done",
       "translation": "Got it 👍 envíame la palabra *DONE* para terminar.",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "es"
     },
     {
-      "id": 1824,
       "label": "self_eval",
       "translation": "On a scale of 1-5, how did you feel about this lesson?\n5 = 🤩 I loved it\n4 = 😁 I liked it\n3 = 😕 I kind of liked it\n2 = 😟 I didn't like it\n1 = 🤬 I hated it it",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "en"
     },
     {
-      "id": 2190,
       "label": "self_eval",
       "translation": "Sur une échelle de 1 à 5, comment avez-vous ressenti cette leçon?\n5 = 🤩 J'ai adoré\n4 = 😁 je l'ai aimé\n3 = 😕 J'ai un peu aimé\n2 = 😟 je n'ai pas aimé\n1 = 🤬 je détestais ç",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 2834,
-      "label": "newspaper",
-      "translation": "periódico",
-      "translation_type": "vocab",
-      "created_at": "2020-02-23T07:35:33Z",
-      "updated_at": "2020-02-23T07:35:52Z",
-      "language": "es"
-    },
-    {
-      "id": 2901,
-      "label": "listen_to_the_audio_write_what_you_hear",
-      "translation": "🔊🎯Escucha el audio. Escribe las palabras que escuchas.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T00:50:02Z",
-      "updated_at": "2020-02-29T00:50:02Z",
-      "language": "es"
-    },
-    {
-      "id": 2843,
-      "label": "practice_speaking_complete_the_dialog_below",
-      "translation": "🗣 Practice Speaking! Complete the dialog below.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T20:21:44Z",
-      "updated_at": "2020-02-23T20:21:52Z",
-      "language": "en"
-    },
-    {
-      "id": 2944,
-      "label": "dough",
-      "translation": "masa",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:31:54Z",
-      "updated_at": "2020-02-29T21:31:54Z",
-      "language": "es"
-    },
-    {
-      "id": 2946,
-      "label": "hand_mixer",
-      "translation": "mezclador de la mano",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:32:19Z",
-      "updated_at": "2020-02-29T21:32:19Z",
-      "language": "es"
-    },
-    {
-      "id": 2902,
-      "label": "listen_to_the_audio_write_what_you_hear",
-      "translation": "🔊🎯Listen to the audio. Write the words you hear.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T00:50:09Z",
-      "updated_at": "2020-02-29T00:50:09Z",
-      "language": "en"
-    },
-    {
-      "id": 2947,
-      "label": "hand_mixer",
-      "translation": "batteur à main\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:32:27Z",
-      "updated_at": "2020-02-29T21:32:27Z",
-      "language": "fr"
-    },
-    {
-      "id": 2903,
-      "label": "listen_to_the_audio_write_what_you_hear",
-      "translation": "🔊🎯Écoutez l'enregistrement. Écrivez les mots que vous entendez.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T00:50:12Z",
-      "updated_at": "2020-02-29T00:50:12Z",
-      "language": "fr"
-    },
-    {
-      "id": 2839,
-      "label": "practice_speaking_say_the_word_below",
-      "translation": "🗣Entraînez-vous à l'orale! Dites le mot suivant 3 fois.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T20:06:29Z",
-      "updated_at": "2020-02-23T20:06:50Z",
-      "language": "fr"
-    },
-    {
-      "id": 2842,
-      "label": "which_phrase_is_correct",
-      "translation": "🤓Quelle phrase est correcte?",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T20:19:22Z",
-      "updated_at": "2020-02-24T03:08:22Z",
-      "language": "fr"
-    },
-    {
-      "id": 2908,
-      "label": "soy",
-      "translation": "soy",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:04Z",
-      "updated_at": "2020-02-29T21:26:04Z",
-      "language": "en"
-    },
-    {
-      "id": 2911,
-      "label": "mixing_bowl",
-      "translation": "mixing bowl",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:22Z",
-      "updated_at": "2020-02-29T21:26:22Z",
-      "language": "en"
-    },
-    {
-      "id": 2912,
-      "label": "stand_mixer",
-      "translation": "stand mixer",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:27Z",
-      "updated_at": "2020-02-29T21:26:27Z",
-      "language": "en"
-    },
-    {
-      "id": 2913,
-      "label": "baking_sheet",
-      "translation": "baking sheet",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:31Z",
-      "updated_at": "2020-02-29T21:26:31Z",
-      "language": "en"
-    },
-    {
-      "id": 2915,
-      "label": "roll_out",
-      "translation": "roll out",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:42Z",
-      "updated_at": "2020-02-29T21:26:42Z",
-      "language": "en"
-    },
-    {
-      "id": 2916,
-      "label": "inch",
-      "translation": "inch",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:45Z",
-      "updated_at": "2020-02-29T21:26:45Z",
-      "language": "en"
-    },
-    {
-      "id": 2918,
-      "label": "scale",
-      "translation": "scale",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:26:56Z",
-      "updated_at": "2020-02-29T21:26:56Z",
-      "language": "en"
-    },
-    {
-      "id": 2952,
-      "label": "baking_sheet",
-      "translation": "bandeja del horno",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:34:28Z",
-      "updated_at": "2020-02-29T21:34:28Z",
-      "language": "es"
-    },
-    {
-      "id": 2953,
-      "label": "baking_sheet",
-      "translation": "plaque de four\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:34:35Z",
-      "updated_at": "2020-02-29T21:34:35Z",
-      "language": "fr"
-    },
-    {
-      "id": 2955,
-      "label": "rolling_pin",
-      "translation": "rouleau",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:37:18Z",
-      "updated_at": "2020-02-29T21:37:18Z",
-      "language": "fr"
-    },
-    {
-      "id": 2956,
-      "label": "roll_out",
-      "translation": "extender con el rodillo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:37:45Z",
-      "updated_at": "2020-02-29T21:37:45Z",
-      "language": "es"
-    },
-    {
-      "id": 2957,
-      "label": "roll_out",
-      "translation": "étendre avec le rouleau\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:37:53Z",
-      "updated_at": "2020-02-29T21:37:53Z",
-      "language": "fr"
-    },
-    {
-      "id": 2958,
-      "label": "inch",
-      "translation": "pulgada",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:38:06Z",
-      "updated_at": "2020-02-29T21:38:06Z",
-      "language": "es"
-    },
-    {
-      "id": 2959,
-      "label": "inch",
-      "translation": "pouce",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:38:13Z",
-      "updated_at": "2020-02-29T21:38:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 2960,
-      "label": "thick",
-      "translation": "espesor",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:38:43Z",
-      "updated_at": "2020-02-29T21:38:43Z",
-      "language": "es"
-    },
-    {
-      "id": 2963,
-      "label": "scale",
-      "translation": "équilibre",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:39:33Z",
-      "updated_at": "2020-02-29T21:39:33Z",
-      "language": "fr"
-    },
-    {
-      "id": 2964,
-      "label": "clipboard",
-      "translation": "panneau d'agrafe\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:40:30Z",
-      "updated_at": "2020-02-29T21:40:30Z",
-      "language": "fr"
-    },
-    {
-      "id": 2972,
-      "label": "receipt_paper",
-      "translation": "papel de recibo\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:42:01Z",
-      "updated_at": "2020-02-29T21:42:01Z",
-      "language": "es"
-    },
-    {
-      "id": 2976,
-      "label": "really",
-      "translation": "muy",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:43:04Z",
-      "updated_at": "2020-02-29T21:43:04Z",
-      "language": "es"
-    },
-    {
-      "id": 2979,
-      "label": "messy",
-      "translation": "désordre",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:43:37Z",
-      "updated_at": "2020-02-29T21:43:37Z",
-      "language": "fr"
-    },
-    {
-      "id": 2981,
-      "label": "overcooked",
-      "translation": "recuit",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:44:03Z",
-      "updated_at": "2020-02-29T21:44:03Z",
-      "language": "fr"
-    },
-    {
-      "id": 2986,
-      "label": "as_soon_as",
-      "translation": "tan pronto como",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:45:17Z",
-      "updated_at": "2020-02-29T21:45:17Z",
-      "language": "es"
-    },
-    {
-      "id": 2987,
-      "label": "as_soon_as",
-      "translation": "dès que\n",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:45:22Z",
-      "updated_at": "2020-02-29T21:45:22Z",
-      "language": "fr"
-    },
-    {
-      "id": 2990,
-      "label": "immediately",
-      "translation": "inmediatamente",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T21:46:27Z",
-      "updated_at": "2020-02-29T21:46:27Z",
-      "language": "es"
-    },
-    {
-      "id": 3077,
-      "label": "husband",
-      "translation": "marido",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:07:21Z",
-      "updated_at": "2020-02-29T22:07:42Z",
-      "language": "es"
-    },
-    {
-      "id": 3080,
-      "label": "son",
-      "translation": "fils",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:08:01Z",
-      "updated_at": "2020-02-29T22:08:01Z",
-      "language": "fr"
-    },
-    {
-      "id": 3079,
-      "label": "son",
-      "translation": "hijo",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:07:54Z",
-      "updated_at": "2020-02-29T22:07:54Z",
-      "language": "es"
-    },
-    {
-      "id": 3082,
-      "label": "daughter",
-      "translation": "fille",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:08:15Z",
-      "updated_at": "2020-02-29T22:08:15Z",
-      "language": "fr"
-    },
-    {
-      "id": 3083,
-      "label": "wife",
-      "translation": "wife",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:09:12Z",
-      "updated_at": "2020-02-29T22:09:12Z",
-      "language": "en"
-    },
-    {
-      "id": 3084,
-      "label": "wife",
-      "translation": "marida",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:09:20Z",
-      "updated_at": "2020-02-29T22:09:20Z",
-      "language": "es"
-    },
-    {
-      "id": 3085,
-      "label": "wife",
-      "translation": "épouse",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T22:09:33Z",
-      "updated_at": "2020-02-29T22:09:33Z",
-      "language": "fr"
-    },
-    {
-      "id": 3086,
-      "label": "arrange",
-      "translation": "arrange",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T23:52:49Z",
-      "updated_at": "2020-02-29T23:52:49Z",
-      "language": "en"
-    },
-    {
-      "id": 3087,
-      "label": "arrange",
-      "translation": "ordenar",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T23:53:01Z",
-      "updated_at": "2020-02-29T23:53:01Z",
-      "language": "es"
-    },
-    {
-      "id": 3088,
-      "label": "arrange",
-      "translation": "ordonner",
-      "translation_type": "lesson",
-      "created_at": "2020-02-29T23:53:23Z",
-      "updated_at": "2020-02-29T23:53:23Z",
-      "language": "fr"
-    },
-    {
-      "id": 2849,
-      "label": "lets_practice_write_the_word",
-      "translation": "Practiquemos! Escribe la palabra",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T21:59:27Z",
-      "updated_at": "2020-02-23T21:59:27Z",
-      "language": "es"
-    },
-    {
-      "id": 2844,
-      "label": "practice_speaking_complete_the_dialog_below",
-      "translation": "🗣¡Practica hablar! Completa el siguiente dialogo.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T20:21:58Z",
-      "updated_at": "2020-03-01T02:27:03Z",
-      "language": "es"
-    },
-    {
-      "id": 2845,
-      "label": "practice_speaking_complete_the_dialog_below",
-      "translation": "🗣Entraînez-vous à l'orale! Complétez la boîte de dialogue ci-dessous.",
-      "translation_type": "lesson",
-      "created_at": "2020-02-23T20:22:08Z",
-      "updated_at": "2020-03-01T02:27:32Z",
-      "language": "fr"
-    },
-    {
-      "id": 3091,
-      "label": "intake_whats_your_level",
-      "translation": "👋 *¿Cuál número describe su nivel de inglés en este momento?* 🧐\n\n1. No hablo nada.\n2. No hablo, pero entiendo los básicos. \n3. Hablo y entiendo los básicos.\n4. Hablo y entiendo frases.\n5. Hablo, entiendo, y escribo frases.\n6. Hablo y escribo casi con fluidez.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:42:19Z",
-      "updated_at": "2020-03-01T02:42:19Z",
-      "language": "es"
-    },
-    {
-      "id": 3090,
-      "label": "intake_whats_your_level",
-      "translation": "👋 *What number describes your level of English?* 🧐\n\n1. I don't speak anything.\n2. I don't speak, but I understand the basics.\n3. I speak and understand the basics.\n4. I speak and understand sentences.\n5. I speak, understand and write sentences.\n6. I speak and write almost fluently.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:41:51Z",
-      "updated_at": "2020-03-01T02:43:15Z",
-      "language": "en"
-    },
-    {
-      "id": 3092,
-      "label": "intake_whats_your_level",
-      "translation": "👋 *Quel nombre décrit votre niveau d'anglais en ce moment?* 🧐\n\n1. Je ne parle rien.\n2. Je ne parle pas, mais je comprends les bases.\n3. Je parle et comprends les bases.\n4. Je parle et comprends des phrases.\n5. Je parle, comprends et écris des phrases.\n6. Je parle et écris presque couramment.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:42:38Z",
-      "updated_at": "2020-03-01T02:43:22Z",
-      "language": "fr"
-    },
-    {
-      "id": 3094,
-      "label": "intake_whats_your_job",
-      "translation": "*En cuál posición de trabajo está usted?*\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:43:43Z",
-      "updated_at": "2020-03-01T02:43:43Z",
-      "language": "es"
-    },
-    {
-      "id": 3093,
-      "label": "intake_whats_your_job",
-      "translation": "What is your job?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:43:38Z",
-      "updated_at": "2020-03-01T02:43:50Z",
-      "language": "en"
-    },
-    {
-      "id": 3095,
-      "label": "intake_whats_your_job",
-      "translation": "*Quel poste occupez-vous?*",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:44:04Z",
-      "updated_at": "2020-03-01T02:44:04Z",
-      "language": "fr"
-    },
-    {
-      "id": 3100,
-      "label": "intake_what_days_do_you_work",
-      "translation": "*Cuáles días trabaja usted?* 🗓\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:45:25Z",
-      "updated_at": "2020-03-01T02:45:25Z",
-      "language": "es"
-    },
-    {
-      "id": 3099,
-      "label": "intake_what_days_do_you_work",
-      "translation": "*What days do you work?* 🗓\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:45:21Z",
-      "updated_at": "2020-03-01T02:45:35Z",
-      "language": "en"
-    },
-    {
-      "id": 3101,
-      "label": "intake_what_days_do_you_work",
-      "translation": "*Quels jours travaillez-vous?* 🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:45:46Z",
-      "updated_at": "2020-03-01T02:45:46Z",
-      "language": "fr"
-    },
-    {
-      "id": 3103,
-      "label": "intake_what_time_do_you_prefer_for_lessons",
-      "translation": "*Durante su turno, a qué hora prefiere recibir sus lecciones?*⌚️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:46:28Z",
-      "updated_at": "2020-03-01T02:46:28Z",
-      "language": "es"
-    },
-    {
-      "id": 3104,
-      "label": "intake_what_time_do_you_prefer_for_lessons",
-      "translation": "*Pendant votre quart de travail, à quelle heure préférez-vous recevoir vos leçons?* ⌚️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:46:37Z",
-      "updated_at": "2020-03-01T02:46:37Z",
-      "language": "fr"
-    },
-    {
-      "id": 3102,
-      "label": "intake_what_time_do_you_prefer_for_lessons",
-      "translation": "*What time do you prefer to receive lessons during your shift?* ⌚️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:46:23Z",
-      "updated_at": "2020-03-01T02:47:04Z",
-      "language": "en"
-    },
-    {
-      "id": 3107,
       "label": "thank_you",
       "translation": "Merci!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:48:10Z",
-      "updated_at": "2020-03-01T02:48:10Z",
       "language": "fr"
     },
     {
-      "id": 3105,
       "label": "thank_you",
       "translation": "Thanks!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:48:00Z",
-      "updated_at": "2020-03-01T02:48:14Z",
       "language": "en"
     },
     {
-      "id": 3109,
-      "label": "intake_i_have_some_questions",
-      "translation": "Tengo unas preguntas para registrarte! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:48:44Z",
-      "updated_at": "2020-03-01T02:48:44Z",
-      "language": "es"
-    },
-    {
-      "id": 3110,
-      "label": "intake_i_have_some_questions",
-      "translation": "J'ai des questions pour m'inscrire!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:49:02Z",
-      "updated_at": "2020-03-01T02:49:02Z",
-      "language": "fr"
-    },
-    {
-      "id": 3108,
-      "label": "intake_i_have_some_questions",
-      "translation": "I have some questions for you. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:48:35Z",
-      "updated_at": "2020-03-01T02:49:14Z",
-      "language": "en"
-    },
-    {
-      "id": 3112,
-      "label": "intake_thanks_lets_start_your_lessons",
-      "translation": "¡Bienvenidos a su clase de inglés! 🎉 \n\nEscriba la palabra *start* para empezar.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:52:49Z",
-      "updated_at": "2020-03-01T02:54:08Z",
-      "language": "es"
-    },
-    {
-      "id": 3113,
-      "label": "intake_thanks_lets_start_your_lessons",
-      "translation": "Bienvenue dans votre cours d'anglais! 🎉\n\nTapez le mot *start* pour commencer.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:53:45Z",
-      "updated_at": "2020-03-01T02:54:15Z",
-      "language": "fr"
-    },
-    {
-      "id": 3098,
       "label": "intake_whats_your_full_name",
       "translation": "Quel est votre nom complet?\n(prénom et nom)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:44:53Z",
-      "updated_at": "2020-03-24T16:42:49Z",
       "language": "fr"
     },
     {
-      "id": 3097,
       "label": "intake_whats_your_full_name",
       "translation": "Cuál es su nombre completo?\n(primer nombre y apellido)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:44:44Z",
-      "updated_at": "2020-03-24T16:42:41Z",
       "language": "es"
     },
     {
-      "id": 3111,
-      "label": "intake_thanks_lets_start_your_lessons",
-      "translation": "Welcome to your English class. 🎉 \n\nWrite the word *start* to begin.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:52:35Z",
-      "updated_at": "2020-03-01T02:53:22Z",
-      "language": "en"
-    },
-    {
-      "id": 3114,
-      "label": "free",
-      "translation": "free",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:55:03Z",
-      "updated_at": "2020-03-01T02:55:03Z",
-      "language": "en"
-    },
-    {
-      "id": 3115,
-      "label": "free",
-      "translation": "gratis",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:55:15Z",
-      "updated_at": "2020-03-01T02:55:15Z",
-      "language": "es"
-    },
-    {
-      "id": 3116,
-      "label": "free",
-      "translation": "gratuit",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:55:21Z",
-      "updated_at": "2020-03-01T02:55:21Z",
-      "language": "fr"
-    },
-    {
-      "id": 3118,
-      "label": "intake_orientation_free",
-      "translation": "Este programa es ofrecido por tu empleador. Es gratis! 🍀",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:56:49Z",
-      "updated_at": "2020-03-01T02:56:49Z",
-      "language": "es"
-    },
-    {
-      "id": 3126,
-      "label": "show_up",
-      "translation": "show up",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T21:15:02Z",
-      "updated_at": "2020-03-01T21:15:02Z",
-      "language": "en"
-    },
-    {
-      "id": 3119,
-      "label": "intake_orientation_free",
-      "translation": "Ce programme est offert par votre employeur. C'est gratuit! 🍀",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:57:15Z",
-      "updated_at": "2020-03-01T02:57:15Z",
-      "language": "fr"
-    },
-    {
-      "id": 3117,
-      "label": "intake_orientation_free",
-      "translation": "This program is offered by your employer. It's free! 🍀",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:56:44Z",
-      "updated_at": "2020-03-01T02:57:21Z",
-      "language": "en"
-    },
-    {
-      "id": 3121,
-      "label": "intake_orientation_shift",
-      "translation": "Recibes una lección cada turno. Lecciones toman 5 minutos para completar. 🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:58:51Z",
-      "updated_at": "2020-03-01T03:00:35Z",
-      "language": "es"
-    },
-    {
-      "id": 3120,
-      "label": "intake_orientation_shift",
-      "translation": "You get 1 lesson every workday. Lessons take 5 minutes to complete.  🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:58:44Z",
-      "updated_at": "2020-03-01T03:00:39Z",
-      "language": "en"
-    },
-    {
-      "id": 3122,
-      "label": "intake_orientation_shift",
-      "translation": "Vous recevez une leçon à chaque tour. Les leçons durent 5 minutes. 🗓\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T03:00:49Z",
-      "updated_at": "2020-03-01T03:00:49Z",
-      "language": "fr"
-    },
-    {
-      "id": 3127,
-      "label": "show_up",
-      "translation": "aparecer",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T21:15:34Z",
-      "updated_at": "2020-03-01T21:15:34Z",
-      "language": "es"
-    },
-    {
-      "id": 3124,
-      "label": "intake_finished",
-      "translation": "¡Terminado! 🙌 🎉 😎\n\nUsted recibirá su primera lección en su próximo turno! 🗓\n\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T03:02:08Z",
-      "updated_at": "2020-03-01T03:05:18Z",
-      "language": "es"
-    },
-    {
-      "id": 3125,
-      "label": "intake_finished",
-      "translation": "C'est fini! 🙌 🎉 😎\n\nVous recevrez votre première leçon lors de votre prochain tour! 🗓\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T03:02:29Z",
-      "updated_at": "2020-03-01T03:05:24Z",
-      "language": "fr"
-    },
-    {
-      "id": 3123,
-      "label": "intake_finished",
-      "translation": "Finished! 🙌 🎉 😎\n\nYou will get your first lesson on your next shift! 🗓\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T03:01:49Z",
-      "updated_at": "2020-03-01T03:05:11Z",
-      "language": "en"
-    },
-    {
-      "id": 3128,
-      "label": "show_up",
-      "translation": "apparaître\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T21:15:57Z",
-      "updated_at": "2020-03-01T21:15:57Z",
-      "language": "fr"
-    },
-    {
-      "id": 3129,
-      "label": "often",
-      "translation": "often",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T21:32:10Z",
-      "updated_at": "2020-03-01T21:32:10Z",
-      "language": "en"
-    },
-    {
-      "id": 3130,
-      "label": "often",
-      "translation": "a menudo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T21:32:33Z",
-      "updated_at": "2020-03-01T21:32:33Z",
-      "language": "es"
-    },
-    {
-      "id": 3131,
-      "label": "often",
-      "translation": "souvent",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T21:32:44Z",
-      "updated_at": "2020-03-01T21:32:44Z",
-      "language": "fr"
-    },
-    {
-      "id": 3132,
-      "label": "which_phrase_is_true",
-      "translation": "Which phrase is true?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:09:41Z",
-      "updated_at": "2020-03-02T05:09:41Z",
-      "language": "en"
-    },
-    {
-      "id": 3133,
-      "label": "which_phrase_is_true",
-      "translation": "Cuál frase es verdad?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:10:20Z",
-      "updated_at": "2020-03-02T05:10:20Z",
-      "language": "es"
-    },
-    {
-      "id": 3134,
-      "label": "which_phrase_is_true",
-      "translation": "Quelle phrase est vraie?\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:10:37Z",
-      "updated_at": "2020-03-02T05:10:37Z",
-      "language": "fr"
-    },
-    {
-      "id": 3106,
       "label": "thank_you",
       "translation": "¡Gracias! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:48:07Z",
-      "updated_at": "2020-03-24T00:33:34Z",
       "language": "es"
     },
     {
-      "id": 3096,
       "label": "intake_whats_your_full_name",
       "translation": "What's your full name?\n(First and Last)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-01T02:44:26Z",
-      "updated_at": "2020-03-24T16:42:34Z",
       "language": "en"
     },
     {
-      "id": 3135,
-      "label": "checking_choices",
-      "translation": "a) my lessons are perfect\nb) send me lessons at a different time\nc) send me easier lessons\nd) send me harder lessons\ne) something else (write it)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:27:01Z",
-      "updated_at": "2020-03-02T05:27:30Z",
-      "language": "en"
-    },
-    {
-      "id": 3332,
-      "label": "bad",
-      "translation": "mal",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3137,
-      "label": "checking_choices",
-      "translation": "a) sont parfaits\nb) m'envoyer des leçons à un autre moment\nc) envoyez-moi des leçons plus faciles\nd) m'envoyer des leçons plus difficiles\ne) autre chose",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:27:45Z",
-      "updated_at": "2020-03-08T05:25:56Z",
-      "language": "fr"
-    },
-    {
-      "id": 3141,
-      "label": "you_will_receive_your_5_minute_lessons_each_shift",
-      "translation": "You will receive your 5 minute lessons each shift. Do your lessons during your shift.  🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-04T00:03:35Z",
-      "updated_at": "2020-03-04T00:05:13Z",
-      "language": "en"
-    },
-    {
-      "id": 3142,
-      "label": "you_will_receive_your_5_minute_lessons_each_shift",
-      "translation": "Recibirá lecciones de 5 minutos cada turno. Complétalos durante su turno.  🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-04T00:04:01Z",
-      "updated_at": "2020-03-04T00:05:18Z",
-      "language": "es"
-    },
-    {
-      "id": 3143,
-      "label": "you_will_receive_your_5_minute_lessons_each_shift",
-      "translation": "Vous recevrez des leçons de 5 minutes à chaque quart de travail. Complétez-les pendant votre quart de travail. 🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-04T00:04:54Z",
-      "updated_at": "2020-03-04T00:05:26Z",
-      "language": "fr"
-    },
-    {
-      "id": 3144,
-      "label": "toppings",
-      "translation": "toppings",
-      "translation_type": "lesson",
-      "created_at": "2020-03-07T19:45:04Z",
-      "updated_at": "2020-03-07T19:45:04Z",
-      "language": "en"
-    },
-    {
-      "id": 3145,
-      "label": "toppings",
-      "translation": "los ingredientes de la cobertura",
-      "translation_type": "lesson",
-      "created_at": "2020-03-07T19:45:12Z",
-      "updated_at": "2020-03-07T19:45:12Z",
-      "language": "es"
-    },
-    {
-      "id": 3146,
-      "label": "toppings",
-      "translation": "les ingrédients de couverture\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-07T19:45:29Z",
-      "updated_at": "2020-03-07T19:45:29Z",
-      "language": "fr"
-    },
-    {
-      "id": 3159,
-      "label": "move_up_question",
-      "translation": "What would you like to do? 👇\n\na) move up to a more difficult level\nb) move down to an easier level\nc) stay in this level",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:56:32Z",
-      "updated_at": "2020-03-08T01:58:10Z",
-      "language": "en"
-    },
-    {
-      "id": 3148,
-      "label": "do_you_prefer_whatsapp_or_sms",
-      "translation": "Hola {{name}}! Prefiere recibir su lecciones por Whatsapp o texto normal? ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:19:11Z",
-      "updated_at": "2020-03-08T01:19:46Z",
-      "language": "es"
-    },
-    {
-      "id": 3147,
-      "label": "do_you_prefer_whatsapp_or_sms",
-      "translation": "Hi {{name}}! Do you want to get your lessons on Whatsapp or regular text message?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:19:00Z",
-      "updated_at": "2020-03-08T01:19:52Z",
-      "language": "en"
-    },
-    {
-      "id": 3149,
-      "label": "do_you_prefer_whatsapp_or_sms",
-      "translation": "Salut {{name}}! Préférez-vous recevoir vos leçons par WhatsApp ou texte normal?\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:20:15Z",
-      "updated_at": "2020-03-08T01:20:15Z",
-      "language": "fr"
-    },
-    {
-      "id": 3160,
-      "label": "move_up_question",
-      "translation": "¿Qué te gustaría hacer? 👇\n\na) subir a un nivel más difícil\nb) bajar a un nivel más fácil\nc) permanecer en este nivel",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:57:51Z",
-      "updated_at": "2020-03-08T01:58:19Z",
-      "language": "es"
-    },
-    {
-      "id": 3150,
-      "label": "eod_support",
-      "translation": "Gabby went home for the day. Please type a message for her. She will respond in the morning. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:22:41Z",
-      "updated_at": "2020-03-08T01:23:41Z",
-      "language": "en"
-    },
-    {
-      "id": 3151,
-      "label": "eod_support",
-      "translation": "Gabby se fue a casa por el día. Por favor, escriba un mensaje para ella. Responderá por la mañana.\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:23:26Z",
-      "updated_at": "2020-03-08T01:23:58Z",
-      "language": "es"
-    },
-    {
-      "id": 3152,
-      "label": "eod_support",
-      "translation": "Gabby est rentré chez lui pour la journée. Veuillez lui écrire un message. Répondra le matin.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:23:46Z",
-      "updated_at": "2020-03-08T01:24:07Z",
-      "language": "fr"
-    },
-    {
-      "id": 3139,
-      "label": "check_in_question",
-      "translation": "¿Cómo van tus lecciones? 🙂",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:28:51Z",
-      "updated_at": "2020-03-08T04:57:53Z",
-      "language": "es"
-    },
-    {
-      "id": 3177,
-      "label": "completed_level_check_in_1_10",
-      "translation": "Sur une échelle de 1 à 10, (1 = très mauvais, 10 = parfait), comment évalueriez-vous vos cours d'anglais jusqu'à présent?\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T03:12:12Z",
-      "updated_at": "2020-03-08T03:12:12Z",
-      "language": "fr"
-    },
-    {
-      "id": 3157,
-      "label": "completed_level_no_question",
-      "translation": "Has completado este nivel de inglés con éxito. Buen trabajo!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:53:54Z",
-      "updated_at": "2020-03-08T01:53:54Z",
-      "language": "es"
-    },
-    {
-      "id": 3158,
-      "label": "completed_level_no_question",
-      "translation": "Vous avez réussi ce niveau d'anglais. Bon travail!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:54:01Z",
-      "updated_at": "2020-03-08T01:54:01Z",
-      "language": "fr"
-    },
-    {
-      "id": 3156,
-      "label": "completed_level_no_question",
-      "translation": "You've successfully completed this level! Great job! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:53:40Z",
-      "updated_at": "2020-03-08T01:54:16Z",
-      "language": "en"
-    },
-    {
-      "id": 3175,
-      "label": "completed_level_check_in_1_10",
-      "translation": "On a scale of 1-10, (1 = very bad, 10 = perfect) how would you rate your English lessons so far?\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T03:11:50Z",
-      "updated_at": "2020-03-08T03:12:47Z",
-      "language": "en"
-    },
-    {
-      "id": 3161,
-      "label": "move_up_question",
-      "translation": "Qu'est-ce que tu aimerais faire? 👇\n\na) monter à un niveau plus difficile\nb) descendre à un niveau plus facile\nc) rester à ce niveau",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:58:00Z",
-      "updated_at": "2020-03-08T01:58:27Z",
-      "language": "fr"
-    },
-    {
-      "id": 3154,
-      "label": "congrats",
-      "translation": "¡Felicidades! 🎉",
-      "translation_type": "vocab",
-      "created_at": "2020-03-08T01:52:25Z",
-      "updated_at": "2020-03-08T02:27:41Z",
-      "language": "es"
-    },
-    {
-      "id": 3153,
-      "label": "congrats",
-      "translation": "Congratulations! 🎉",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T01:51:56Z",
-      "updated_at": "2020-03-08T02:27:50Z",
-      "language": "en"
-    },
-    {
-      "id": 3162,
-      "label": "roll",
-      "translation": "roll",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T02:39:01Z",
-      "updated_at": "2020-03-08T02:39:01Z",
-      "language": "en"
-    },
-    {
-      "id": 3163,
-      "label": "roll",
-      "translation": "enrollar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T02:39:10Z",
-      "updated_at": "2020-03-08T02:39:10Z",
-      "language": "es"
-    },
-    {
-      "id": 3164,
-      "label": "roll",
-      "translation": "enrouler",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T02:39:31Z",
-      "updated_at": "2020-03-08T02:39:31Z",
-      "language": "fr"
-    },
-    {
-      "id": 3165,
-      "label": "polish",
-      "translation": "polish",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T02:42:42Z",
-      "updated_at": "2020-03-08T02:42:42Z",
-      "language": "en"
-    },
-    {
-      "id": 3166,
-      "label": "polish",
-      "translation": "lustrar ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T02:42:53Z",
-      "updated_at": "2020-03-08T02:43:22Z",
-      "language": "es"
-    },
-    {
-      "id": 3167,
-      "label": "polish",
-      "translation": "polir",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T02:43:31Z",
-      "updated_at": "2020-03-08T02:43:31Z",
-      "language": "fr"
-    },
-    {
-      "id": 3169,
-      "label": "fill",
-      "translation": "llenar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T02:53:25Z",
-      "updated_at": "2020-03-08T02:53:25Z",
-      "language": "es"
-    },
-    {
-      "id": 3170,
-      "label": "fill",
-      "translation": "faire le plein\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T02:53:35Z",
-      "updated_at": "2020-03-08T02:53:35Z",
-      "language": "fr"
-    },
-    {
-      "id": 3168,
-      "label": "fill",
-      "translation": "fill",
-      "translation_type": "vocab",
-      "created_at": "2020-03-08T02:53:09Z",
-      "updated_at": "2020-03-08T02:53:47Z",
-      "language": "en"
-    },
-    {
-      "id": 3172,
-      "label": "wipe",
-      "translation": "limpiar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T03:01:56Z",
-      "updated_at": "2020-03-08T03:01:56Z",
-      "language": "es"
-    },
-    {
-      "id": 3173,
-      "label": "wipe",
-      "translation": "nettoyer\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T03:02:08Z",
-      "updated_at": "2020-03-08T03:02:08Z",
-      "language": "fr"
-    },
-    {
-      "id": 3171,
-      "label": "wipe",
-      "translation": "wipe",
-      "translation_type": "vocab",
-      "created_at": "2020-03-08T02:59:23Z",
-      "updated_at": "2020-03-08T03:02:26Z",
-      "language": "en"
-    },
-    {
-      "id": 3176,
-      "label": "completed_level_check_in_1_10",
-      "translation": "En una escala de 1-10, (1 = muy mal, 10 = perfecto) ¿cómo calificaría sus lecciones de inglés hasta ahora?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T03:12:00Z",
-      "updated_at": "2020-03-08T03:12:00Z",
-      "language": "es"
-    },
-    {
-      "id": 3178,
-      "label": "completed_level_1_next_shift_level_2",
-      "translation": "Ok! You will start LEVEL 2 lessons on your next shift. 😎  \n\nFor today, take a break from your lessons and celebrate! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:01:11Z",
-      "updated_at": "2020-03-08T04:04:44Z",
-      "language": "en"
-    },
-    {
-      "id": 3184,
-      "label": "completed_level_1_next_shift_level_2",
-      "translation": "Ok! Vous commencerez les leçons de NIVEAU 2 lors de votre prochain tour. 😎\n\nPour aujourd'hui, faites une pause dans vos cours et célébrez! 🙌 🎉",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:05:53Z",
-      "updated_at": "2020-03-08T04:05:53Z",
-      "language": "fr"
-    },
-    {
-      "id": 3181,
-      "label": "completed_level_4_next_shift_level_5",
-      "translation": "Ok! You will start LEVEL 5 lessons on your next shift. 😎  \n\nFor today, take a break from your lessons and celebrate! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:01:48Z",
-      "updated_at": "2020-03-08T04:07:46Z",
-      "language": "en"
-    },
-    {
-      "id": 3183,
-      "label": "completed_level_1_next_shift_level_2",
-      "translation": "Ok! Comenzarás las lecciones de NIVEL 2 en tu próximo turno. 😎  \n\nPara hoy, tome un descanso de sus lecciones y celebre! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:05:22Z",
-      "updated_at": "2020-03-08T04:09:20Z",
-      "language": "es"
-    },
-    {
-      "id": 3195,
-      "label": "completed_level_send_go",
-      "translation": "Tapez le mot \"GO\" pour continuer.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:13:34Z",
-      "updated_at": "2020-03-08T04:13:50Z",
-      "language": "fr"
-    },
-    {
-      "id": 3155,
-      "label": "congrats",
-      "translation": "Félicitations!  🎉",
-      "translation_type": "vocab",
-      "created_at": "2020-03-08T01:52:42Z",
-      "updated_at": "2020-03-08T04:24:50Z",
-      "language": "fr"
-    },
-    {
-      "id": 3333,
-      "label": "baking_sheet",
-      "translation": "bandeja de forno",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3138,
-      "label": "check_in_question",
-      "translation": "How are your lessons going? 🙂",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:28:10Z",
-      "updated_at": "2020-03-08T04:57:48Z",
-      "language": "en"
-    },
-    {
-      "id": 3140,
-      "label": "check_in_question",
-      "translation": "Comment se passent tes leçons? 🙂\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:28:58Z",
-      "updated_at": "2020-03-08T04:57:57Z",
-      "language": "fr"
-    },
-    {
-      "id": 3334,
-      "label": "be_conscience_of",
-      "translation": "porque",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3335,
-      "label": "because",
-      "translation": "ser consciente de",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3336,
-      "label": "before",
-      "translation": "antes",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3337,
-      "label": "beforehand",
-      "translation": "de antemão",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3338,
-      "label": "beforehand",
-      "translation": "de antemão",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3339,
-      "label": "behind",
-      "translation": "atrás de",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3179,
-      "label": "completed_level_2_next_shift_level_3",
-      "translation": "Ok! You will start LEVEL 3 lessons on your next shift. 😎  \n\nFor today, take a break from your lessons and celebrate! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:01:18Z",
-      "updated_at": "2020-03-08T04:06:26Z",
-      "language": "en"
-    },
-    {
-      "id": 3180,
-      "label": "completed_level_3_next_shift_level_4",
-      "translation": "Ok! You will start LEVEL 4 lessons on your next shift. 😎  \n\nFor today, take a break from your lessons and celebrate! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:01:41Z",
-      "updated_at": "2020-03-08T04:07:06Z",
-      "language": "en"
-    },
-    {
-      "id": 3190,
-      "label": "completed_level_4_next_shift_level_5",
-      "translation": "Ok! Vous commencerez les leçons de NIVEAU 5 lors de votre prochain tour. 😎\n\nPour aujourd'hui, faites une pause dans vos cours et célébrez! 🙌 🎉",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:08:09Z",
-      "updated_at": "2020-03-08T04:08:09Z",
-      "language": "fr"
-    },
-    {
-      "id": 3185,
-      "label": "completed_level_2_next_shift_level_3",
-      "translation": "Ok! Comenzarás las lecciones de NIVEL 3 en tu próximo turno. 😎  \n\nPara hoy, tome un descanso de sus lecciones y celebre! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:06:40Z",
-      "updated_at": "2020-03-08T04:09:29Z",
-      "language": "es"
-    },
-    {
-      "id": 3186,
-      "label": "completed_level_2_next_shift_level_3",
-      "translation": "Ok! Vous commencerez les leçons de NIVEAU 3 lors de votre prochain tour. 😎\n\nPour aujourd'hui, faites une pause dans vos cours et célébrez! 🙌 🎉",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:06:49Z",
-      "updated_at": "2020-03-08T04:06:49Z",
-      "language": "fr"
-    },
-    {
-      "id": 3187,
-      "label": "completed_level_3_next_shift_level_4",
-      "translation": "Ok! Comenzarás las lecciones de LEVEL 4 en tu próximo turno. 😎  \n\nPara hoy, tome un descanso de sus lecciones y celebre! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:07:18Z",
-      "updated_at": "2020-03-08T04:07:18Z",
-      "language": "es"
-    },
-    {
-      "id": 3188,
-      "label": "completed_level_3_next_shift_level_4",
-      "translation": "Ok! Vous commencerez les leçons de NIVEAU 4 lors de votre prochain tour. 😎\n\nPour aujourd'hui, faites une pause dans vos cours et célébrez! 🙌 🎉",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:07:27Z",
-      "updated_at": "2020-03-08T04:07:27Z",
-      "language": "fr"
-    },
-    {
-      "id": 3182,
-      "label": "completed_level_5_next_shift_level_6",
-      "translation": "Ok! You will start LEVEL 6 lessons on your next shift. 😎  \n\nFor today, take a break from your lessons and celebrate! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:01:56Z",
-      "updated_at": "2020-03-08T04:08:24Z",
-      "language": "en"
-    },
-    {
-      "id": 3191,
-      "label": "completed_level_5_next_shift_level_6",
-      "translation": "Ok! Comenzarás las lecciones de NIVEL 6 en tu próximo turno. 😎  \n\nPara hoy, tome un descanso de sus lecciones y celebre! 🙌 🎉 \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:08:45Z",
-      "updated_at": "2020-03-08T04:08:45Z",
-      "language": "es"
-    },
-    {
-      "id": 3192,
-      "label": "completed_level_5_next_shift_level_6",
-      "translation": "Ok! Vous commencerez les leçons de NIVEAU 6 lors de votre prochain tour. 😎\n\nPour aujourd'hui, faites une pause dans vos cours et célébrez! 🙌 🎉",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:08:59Z",
-      "updated_at": "2020-03-08T04:08:59Z",
-      "language": "fr"
-    },
-    {
-      "id": 3189,
-      "label": "completed_level_4_next_shift_level_5",
-      "translation": "Ok! Comenzarás las lecciones de NIVEL 5 en tu próximo turno. 😎  \n\nPara hoy, tome un descanso de sus lecciones y celebre! 🙌 🎉 ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:08:01Z",
-      "updated_at": "2020-03-08T04:09:39Z",
-      "language": "es"
-    },
-    {
-      "id": 3193,
-      "label": "completed_level_send_go",
-      "translation": "Write the word \"GO\" to continue. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:12:16Z",
-      "updated_at": "2020-03-08T04:13:42Z",
-      "language": "en"
-    },
-    {
-      "id": 3194,
-      "label": "completed_level_send_go",
-      "translation": "Escriba la palabra \"GO\" para continuar. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:13:27Z",
-      "updated_at": "2020-03-08T04:13:47Z",
-      "language": "es"
-    },
-    {
-      "id": 3198,
-      "label": "completed_60_lessons",
-      "translation": "Wow! You have completed 60 lessons in this level. Nice job!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:46:06Z",
-      "updated_at": "2020-03-08T04:47:46Z",
-      "language": "en"
-    },
-    {
-      "id": 3200,
-      "label": "completed_60_lessons",
-      "translation": "¡Wow! Has completado 60 lecciones en este nivel. ¡Buen trabajo!\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:48:04Z",
-      "updated_at": "2020-03-08T04:48:04Z",
-      "language": "es"
-    },
-    {
-      "id": 3197,
-      "label": "compelted_40_lessons",
-      "translation": "Wow! You have completed 40 lessons in this level. Excellent!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:46:00Z",
-      "updated_at": "2020-03-08T04:48:38Z",
-      "language": "en"
-    },
-    {
-      "id": 3201,
-      "label": "compelted_40_lessons",
-      "translation": "¡Wow! Has completado 40 lecciones en este nivel. Excelente! \n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:48:20Z",
-      "updated_at": "2020-03-08T04:48:49Z",
-      "language": "es"
-    },
-    {
-      "id": 3202,
-      "label": "compelted_40_lessons",
-      "translation": "Ouah! Vous avez suivi 40 leçons à ce niveau. Excellent!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:49:03Z",
-      "updated_at": "2020-03-08T04:49:03Z",
-      "language": "fr"
-    },
-    {
-      "id": 3203,
-      "label": "completed_60_lessons",
-      "translation": "Ouah! Vous avez suivi 60 leçons à ce niveau. Bon travail!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:49:21Z",
-      "updated_at": "2020-03-08T04:49:21Z",
-      "language": "fr"
-    },
-    {
-      "id": 3196,
-      "label": "completed_20_lessons",
-      "translation": "Woah! You have completed 20 lessons in this level! Amazing! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:45:53Z",
-      "updated_at": "2020-03-08T04:49:54Z",
-      "language": "en"
-    },
-    {
-      "id": 3199,
-      "label": "completed_20_lessons",
-      "translation": "¡Wow! Has completado 20 lecciones en este nivel. ¡Maravilloso! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:47:30Z",
-      "updated_at": "2020-03-08T04:50:08Z",
-      "language": "es"
-    },
-    {
-      "id": 3204,
-      "label": "completed_20_lessons",
-      "translation": "Ouah! Vous avez terminé 20 leçons de ce niveau. Merveilleux!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T04:50:14Z",
-      "updated_at": "2020-03-08T04:50:14Z",
-      "language": "fr"
-    },
-    {
-      "id": 3136,
-      "label": "checking_choices",
-      "translation": "a) son perfectas\nb) envíeme lecciones en un horario diferente\nc) envíeme lecciones más fáciles\nd) envíeme lecciones más difíciles\ne) otra cosa ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-02T05:27:15Z",
-      "updated_at": "2020-03-08T05:25:47Z",
-      "language": "es"
-    },
-    {
-      "id": 3205,
-      "label": "got_your_reply_next_lesson_tomorrow",
-      "translation": "Got it! You'll get your next lesson on your next shift! \n\nNo training today! Instead, celebrate your 60th lesson! 🍦",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T06:08:23Z",
-      "updated_at": "2020-03-08T06:10:20Z",
-      "language": "en"
-    },
-    {
-      "id": 3208,
       "label": "ready_for_drill",
       "translation": "Hi {{name}}. {{company}} requires all employees to complete a 5-minute {{lesson_label}} training drill. You can complete it over WhatsApp. Reply YES to begin.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T00:09:15Z",
-      "updated_at": "2020-03-09T00:09:15Z",
       "language": "en"
     },
     {
-      "id": 3216,
       "label": "drill_intro_2",
       "translation": "La formation d'aujourd'hui est: \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:01:01Z",
-      "updated_at": "2020-03-22T20:51:09Z",
       "language": "fr"
     },
     {
-      "id": 3206,
-      "label": "got_your_reply_next_lesson_tomorrow",
-      "translation": "¡Entiendo! ¡Tendrás tu próxima lección en tu próximo turno!\n\nNinguna lección hoy! ¡En lugar de eso celebra tu 60a lección! 🍦",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T06:10:48Z",
-      "updated_at": "2020-03-08T06:12:55Z",
-      "language": "es"
-    },
-    {
-      "id": 3207,
-      "label": "got_your_reply_next_lesson_tomorrow",
-      "translation": "Je comprends Vous aurez votre prochaine leçon à votre prochain tour!\n\nAucune leçon aujourd'hui! Au lieu de cela, célébrez votre 60e leçon! 🍦",
-      "translation_type": "lesson",
-      "created_at": "2020-03-08T06:13:19Z",
-      "updated_at": "2020-03-08T06:13:19Z",
-      "language": "fr"
-    },
-    {
-      "id": 3209,
       "label": "ready_for_drill",
       "translation": "Hola, {{name}}. {{company}} requiere que todos los empleados completen un simulacro de capacitación de {{lesson_label}} de 5 minutos. Puedes completarlo a través de WhatsApp. Responda SI para comenzar.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T00:09:23Z",
-      "updated_at": "2020-03-09T00:09:23Z",
       "language": "es"
     },
     {
-      "id": 3210,
       "label": "ready_for_drill",
       "translation": "Salut {{name}}. Votre employeur, {{company}} exige que vous terminiez un {{lesson_label}} exercice de formation de 5 minutes. Vous pouvez le compléter sur WhatsApp. Répondez OUI pour commencer.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T00:09:24Z",
-      "updated_at": "2020-03-09T00:09:24Z",
       "language": "fr"
     },
     {
-      "id": 3211,
-      "label": "drill_intro_1",
-      "translation": "is asking all employees to complete 5-minute hygiene training drills. You complete them over SMS or Whatsapp. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T03:58:53Z",
-      "updated_at": "2020-03-09T03:59:02Z",
-      "language": "en"
-    },
-    {
-      "id": 3212,
-      "label": "drill_intro_1",
-      "translation": "está pidiendo a todos los empleados que completen entrenamiento en higiene de 5 minutos. Los completas a través de SMS o Whatsapp.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T03:59:24Z",
-      "updated_at": "2020-03-09T03:59:51Z",
-      "language": "es"
-    },
-    {
-      "id": 3213,
-      "label": "drill_intro_1",
-      "translation": "Il demande à tous les employés de suivre une formation en hygiène de 5 minutes. Vous les complétez par SMS ou WhatsApp.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:00:06Z",
-      "updated_at": "2020-03-09T04:00:06Z",
-      "language": "fr"
-    },
-    {
-      "id": 3218,
-      "label": "hand_washing_how_to",
-      "translation": "\"Cómo Lavarse Las Manos Correctamente\" ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:01:57Z",
-      "updated_at": "2020-03-10T05:39:03Z",
-      "language": "es"
-    },
-    {
-      "id": 3219,
-      "label": "hand_washing_how_to",
-      "translation": "\"Comment Bien Se Laver les Mains\" \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:02:14Z",
-      "updated_at": "2020-03-10T05:38:58Z",
-      "language": "fr"
-    },
-    {
-      "id": 3221,
-      "label": "drill_intro_3",
-      "translation": "Por favor, envíeme la palabra \"GO\" para empezar!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:04:19Z",
-      "updated_at": "2020-03-29T23:43:37Z",
-      "language": "es"
-    },
-    {
-      "id": 3214,
       "label": "drill_intro_2",
       "translation": "Today's drill is:",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:00:35Z",
-      "updated_at": "2020-03-12T01:25:29Z",
       "language": "en"
     },
     {
-      "id": 3223,
-      "label": "drill_requirements_1",
-      "translation": "Your manager will give you 5 minutes to complete this drill. 🙂",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:05:25Z",
-      "updated_at": "2020-03-12T00:59:45Z",
-      "language": "en"
-    },
-    {
-      "id": 3226,
-      "label": "drill_requirements_2",
-      "translation": "You must be clocked in before you continue!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:06:30Z",
-      "updated_at": "2020-03-09T04:06:33Z",
-      "language": "en"
-    },
-    {
-      "id": 3224,
-      "label": "drill_requirements_1",
-      "translation": "Su gerente le dará 5 minutos para completar este entrenamiento. 🙂",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:05:54Z",
-      "updated_at": "2020-03-12T00:59:52Z",
-      "language": "es"
-    },
-    {
-      "id": 3230,
-      "label": "drill_requirements_3_start",
-      "translation": "Envíeme la palabra LISTO cuando esté en el trabajo y listo para empezar.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:12:33Z",
-      "updated_at": "2020-03-09T04:12:56Z",
-      "language": "es"
-    },
-    {
-      "id": 3217,
-      "label": "hand_washing_how_to",
-      "translation": "\"Hand-washing How To\" ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:01:32Z",
-      "updated_at": "2020-03-10T05:38:52Z",
-      "language": "en"
-    },
-    {
-      "id": 3222,
-      "label": "drill_intro_3",
-      "translation": "Envoyez-moi le mot \"GO\" pour commencer!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:04:28Z",
-      "updated_at": "2020-03-29T23:43:46Z",
-      "language": "fr"
-    },
-    {
-      "id": 3220,
-      "label": "drill_intro_3",
-      "translation": "Please text me the word GO to start! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:04:01Z",
-      "updated_at": "2020-03-29T23:43:26Z",
-      "language": "en"
-    },
-    {
-      "id": 3227,
-      "label": "drill_requirements_2",
-      "translation": "Debes estar en el trabajo antes de continuar! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:06:47Z",
-      "updated_at": "2020-03-10T18:15:24Z",
-      "language": "es"
-    },
-    {
-      "id": 3215,
       "label": "drill_intro_2",
       "translation": "El entrenamiento de hoy:",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:00:55Z",
-      "updated_at": "2020-03-22T20:04:27Z",
       "language": "es"
     },
     {
-      "id": 3228,
-      "label": "drill_requirements_2",
-      "translation": "Vous devez être inscrit au travail avant de continuer!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:08:52Z",
-      "updated_at": "2020-03-09T04:08:52Z",
-      "language": "fr"
-    },
-    {
-      "id": 3225,
-      "label": "drill_requirements_1",
-      "translation": "Votre gestionnaire vous donnera 5 minutes pour terminer cette formation lors de votre prochain quart de travail. 🙂\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:06:02Z",
-      "updated_at": "2020-03-12T00:58:17Z",
-      "language": "fr"
-    },
-    {
-      "id": 3229,
-      "label": "drill_requirements_3_start",
-      "translation": "Text me the word READY when you're at work and ready to start.\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:12:12Z",
-      "updated_at": "2020-03-12T01:13:03Z",
-      "language": "en"
-    },
-    {
-      "id": 3231,
-      "label": "drill_requirements_3_start",
-      "translation": "Envoyez-moi le mot PRET lorsque je suis au travail et prêt à commencer.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:13:04Z",
-      "updated_at": "2020-03-09T04:13:04Z",
-      "language": "fr"
-    },
-    {
-      "id": 3233,
       "label": "drill_self_assess_1",
       "translation": "¡Ok! Vamos! Vamos a aprender un poco sobre ti primero.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:16:52Z",
-      "updated_at": "2020-03-22T21:05:58Z",
       "language": "es"
     },
     {
-      "id": 3244,
       "label": "drill_how_to_practice_1",
       "translation": "You should only wash your hands with warm water.\n\na) true\nb) false",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:23:17Z",
-      "updated_at": "2020-03-23T01:43:55Z",
       "language": "en"
     },
     {
-      "id": 3234,
       "label": "drill_self_assess_1",
       "translation": "Ok! Allons-y! Tout d’abord, nous aimerions en savoir un peu plus sur vous.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:18:03Z",
-      "updated_at": "2020-03-22T20:10:10Z",
       "language": "fr"
     },
     {
-      "id": 3260,
       "label": "drill_how_to_fact_5",
       "translation": "HECHO: Los gérmenes pueden transferirse más fácilmente entre manos mojadas.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:31:04Z",
-      "updated_at": "2020-03-24T01:00:06Z",
       "language": "es"
     },
     {
-      "id": 3238,
-      "label": "when_to_wash_your_hands",
-      "translation": "When To Wash Your Hands",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:19:55Z",
-      "updated_at": "2020-03-09T04:19:55Z",
-      "language": "en"
-    },
-    {
-      "id": 3241,
       "label": "likert_1_10_knowledge",
       "translation": "(1 = I don't know anything, 10 = I'm great and I teach others)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:21:44Z",
-      "updated_at": "2020-03-09T04:21:50Z",
       "language": "en"
     },
     {
-      "id": 3235,
       "label": "drill_self_assess_2",
       "translation": "On a scale of 1-10, how would you rate your current knowledge of today's topic:",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:19:13Z",
-      "updated_at": "2020-03-24T00:02:22Z",
       "language": "en"
     },
     {
-      "id": 3232,
       "label": "drill_self_assess_1",
       "translation": "Ok! Here we go! Let’s learn a little bit about you first. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:16:28Z",
-      "updated_at": "2020-03-22T21:05:47Z",
       "language": "en"
     },
     {
-      "id": 3245,
       "label": "drill_how_to_practice_1",
       "translation": "Sólo debería lavarse las manos con agua tibia.\n\na) verdadero\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:23:37Z",
-      "updated_at": "2020-03-23T01:43:50Z",
       "language": "es"
     },
     {
-      "id": 3248,
       "label": "drill_how_to_practice_2",
       "translation": "¿Cuánto jabón debería usar cuando se lava las manos?\n\na) 1 bombeo\nb) 2-3 bombeos\nc) nada\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:25:17Z",
-      "updated_at": "2020-03-23T23:57:08Z",
       "language": "es"
     },
     {
-      "id": 3250,
       "label": "drill_how_to_fact_2",
       "translation": "FACT: Hot water is great for getting oil off of your hands! When it comes to germs - hot and cold water are equally effective. Good handwashing is about the amount of soap you use and how long you scrub your hands. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:26:18Z",
-      "updated_at": "2020-03-09T04:26:23Z",
       "language": "en"
     },
     {
-      "id": 3257,
       "label": "drill_how_to_fact_4",
       "translation": "HECHO: Las bacterias son más probables de esconderse debajo de las uñas.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:30:04Z",
-      "updated_at": "2020-03-22T22:21:26Z",
       "language": "es"
     },
     {
-      "id": 3256,
       "label": "drill_how_to_fact_4",
       "translation": "FACT: Bacteria are most likely to be hiding underneath your nails. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:29:43Z",
-      "updated_at": "2020-03-09T04:29:54Z",
       "language": "en"
     },
     {
-      "id": 3258,
       "label": "drill_how_to_fact_4",
       "translation": "FAIT: Les bactéries sont plus susceptibles de se cacher sous les ongles.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:30:11Z",
-      "updated_at": "2020-03-09T04:30:11Z",
       "language": "fr"
     },
     {
-      "id": 3247,
       "label": "drill_how_to_practice_2",
       "translation": "How much soap should you use when you wash your hands?\n\na) 1 pump\nb) 2-3 pumps\nc) none",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:24:46Z",
-      "updated_at": "2020-03-23T23:57:02Z",
       "language": "en"
     },
     {
-      "id": 3261,
       "label": "drill_how_to_fact_5",
       "translation": "LES FAITS: Les germes se transmettent plus facilement entre des mains sont mouillées. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:31:22Z",
-      "updated_at": "2020-03-22T22:41:39Z",
       "language": "fr"
     },
     {
-      "id": 3259,
       "label": "drill_how_to_fact_5",
       "translation": "FACT: Germs can be transferred more easily to and from wet hands.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:30:40Z",
-      "updated_at": "2020-03-23T23:32:16Z",
       "language": "en"
     },
     {
-      "id": 3264,
       "label": "drill_how_to_practice_5",
       "translation": "Quelle est la façon la plus sûre de se sécher les mains? \n\na) Sur un torchon\nb) En les essuyant sur son tablier\nc) En les secouant\nd) Sur votre t-shirt\ne) Avec de l’essuie-tout ou un séchoir",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:33:53Z",
-      "updated_at": "2020-03-24T00:01:27Z",
       "language": "fr"
     },
     {
-      "id": 3266,
       "label": "drill_how_to_practice_4",
       "translation": "Escoja la mejor opción para llenar el blanco. \n\nRestréguese las manos fuertemente con jabón [---].\n\na) durante 10 segundos\nb) durante 20 segundos\nc) durante 60 segundos\nd) si quiere\ne) mientras come",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:39:43Z",
-      "updated_at": "2020-03-22T22:25:02Z",
       "language": "es"
     },
     {
-      "id": 3265,
       "label": "drill_how_to_practice_4",
       "translation": "Choose the best option to fill in the space. \n\nVigorously scrub your hands with soap [---].\n\na) for 10 seconds\nb) for 20 seconds\nc) for 60 seconds\nd) if you want to\ne) while you eat",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:39:24Z",
-      "updated_at": "2020-03-22T22:22:13Z",
       "language": "en"
     },
     {
-      "id": 3340,
-      "label": "benefits",
-      "translation": "benefícios",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3341,
-      "label": "better",
-      "translation": "melhor",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3342,
-      "label": "black",
-      "translation": "preto",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3343,
-      "label": "black_and_white",
-      "translation": "em preto e branco",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3344,
-      "label": "boil",
-      "translation": "ferver",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3345,
-      "label": "box",
-      "translation": "box",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3346,
-      "label": "bread",
-      "translation": "pão",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3239,
-      "label": "when_to_wash_your_hands",
-      "translation": "Cuándo Lavarse Las Manos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:20:20Z",
-      "updated_at": "2020-03-18T01:39:56Z",
-      "language": "es"
-    },
-    {
-      "id": 3243,
       "label": "likert_1_10_knowledge",
       "translation": "(1 = Je ne connais rien, 10 = Je le connais très bien et je l’apprend aux autres)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:22:31Z",
-      "updated_at": "2020-03-22T20:13:22Z",
       "language": "fr"
     },
     {
-      "id": 3236,
       "label": "drill_self_assess_2",
       "translation": "En una escala del 1 al 10, ¿cómo calificaría su conocimiento actual del tema de hoy:",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:19:31Z",
-      "updated_at": "2020-03-19T00:13:24Z",
       "language": "es"
     },
     {
-      "id": 3237,
       "label": "drill_self_assess_2",
       "translation": "Sur une échelle de 1 à 10, comment évaluez-vous vos connaissances sur le sujet d'aujourd'hui: ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:19:37Z",
-      "updated_at": "2020-03-22T20:53:19Z",
       "language": "fr"
     },
     {
-      "id": 3246,
       "label": "drill_how_to_practice_1",
       "translation": "Il faut toujours se laver avec de l’eau chaude. \n\na) Vrai\nb) Faux",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:23:48Z",
-      "updated_at": "2020-03-23T01:43:43Z",
       "language": "fr"
     },
     {
-      "id": 3251,
       "label": "drill_how_to_fact_2",
       "translation": "HECHO: ¡El agua caliente es excelente para quitar el aceite de las manos! Cuando se trata de gérmenes, el agua caliente y fría son igualmente efectivas. Lavarse las manos bien se trata de la cantidad de jabón utilizado y la cantidad de tiempo que se restriega las manos.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:26:51Z",
-      "updated_at": "2020-03-22T22:14:28Z",
       "language": "es"
     },
     {
-      "id": 3249,
       "label": "drill_how_to_practice_2",
       "translation": "Quelle quantité de savon faut-il utiliser quand on se lave les mains? \n\na) 1 goutte\nb) 2-3 gouttes\nc) aucun\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:25:28Z",
-      "updated_at": "2020-03-23T23:57:14Z",
       "language": "fr"
     },
     {
-      "id": 3262,
       "label": "drill_how_to_practice_5",
       "translation": "What is the safest way to dry your hands? \n\na) kitchen towel\nb) wipe on your apron\nc) shaking them \nd) wipe on your shirt\ne) paper towel or air dryer",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:32:13Z",
-      "updated_at": "2020-03-24T00:01:14Z",
       "language": "en"
     },
     {
-      "id": 3255,
       "label": "drill_how_to_fact_3",
       "translation": "LES FAITS: Il faut prendre suffisamment de savon pour couvrir entièrement les mains. Cela correspond à 2 gouttes ou plus. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:29:26Z",
-      "updated_at": "2020-03-22T22:16:24Z",
       "language": "fr"
     },
     {
-      "id": 3253,
       "label": "drill_how_to_fact_3",
       "translation": "FACT: Pump enough soap to cover your hands. That means 2+ pumps! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:28:50Z",
-      "updated_at": "2020-03-22T22:20:21Z",
       "language": "en"
     },
     {
-      "id": 3254,
       "label": "drill_how_to_fact_3",
       "translation": "HECHO: Bombea suficiente jabón como para cubrirte las manos. ¡Eso significa 2 bombeos o más! \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:29:15Z",
-      "updated_at": "2020-03-21T00:29:11Z",
       "language": "es"
     },
     {
-      "id": 3240,
-      "label": "when_to_wash_your_hands",
-      "translation": "\nQuand faut-il se laver les mains\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:20:35Z",
-      "updated_at": "2020-03-21T00:33:50Z",
-      "language": "fr"
-    },
-    {
-      "id": 3242,
       "label": "likert_1_10_knowledge",
       "translation": "(1 = No conozco nada, 10 = Soy un experto y le enseño a otros)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:21:59Z",
-      "updated_at": "2020-03-22T20:14:03Z",
       "language": "es"
     },
     {
-      "id": 3263,
       "label": "drill_how_to_practice_5",
       "translation": "¿Cuál es la forma más segura de secarse las manos? \n\na) toalla de cocina\nb) sacudéndolas\nc) dejarlas secar al aire\nd) en su camisa\ne) toalla de papel o secadores de mano",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:33:36Z",
-      "updated_at": "2020-03-24T00:01:21Z",
       "language": "es"
     },
     {
-      "id": 3269,
       "label": "drill_how_to_practice_3",
       "translation": "Escoja la mejor opción para llenar el blanco. \n\nLávese las palmas y parte superior de sus manos. No olvide restregar entre [---].\n\na) los dedos\nb) los dedos de los pies\nc) los dedos y debajo de las uñas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:41:48Z",
-      "updated_at": "2020-03-22T22:18:33Z",
       "language": "es"
     },
     {
-      "id": 3310,
-      "label": "choose_the_correct_answer",
-      "translation": "Choose the best answer. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T21:25:05Z",
-      "updated_at": "2020-03-10T21:25:25Z",
-      "language": "en"
-    },
-    {
-      "id": 3330,
       "label": "audio_instructions_wa",
       "translation": "🎤  * Use o WhatsApp para enviar seu correio de voz! * 🎤",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3301,
       "label": "drill_complete_congrats",
       "translation": "Congrats {{name}}! Your training drill for today is complete.\n\nWe’ll let {{company}} know you finished.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:39:48Z",
-      "updated_at": "2020-03-22T23:37:42Z",
       "language": "en"
     },
     {
-      "id": 3299,
       "label": "drill_self_assess_3",
       "translation": "(Su respuesta se mantendrá privada.)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:33:06Z",
-      "updated_at": "2020-03-22T20:16:39Z",
       "language": "es"
     },
     {
-      "id": 3329,
       "label": "audio_instructions_sms",
       "translation": "Ligue para +19293352215",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3304,
-      "label": "drill_complete_likert",
-      "translation": "Got a second?\n\nOn a scale of 1-10, how likely are you to recommend this training drill to a coworker? ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:44:58Z",
-      "updated_at": "2020-03-10T05:47:11Z",
-      "language": "en"
-    },
-    {
-      "id": 3307,
-      "label": "likert_1_10_recommend",
-      "translation": "[1 = not likely at all, 10 = extremely likely]",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:47:46Z",
-      "updated_at": "2020-03-10T05:47:50Z",
-      "language": "en"
-    },
-    {
-      "id": 3327,
       "label": "audio_instructions_full_sms",
       "translation": "1. Ligue * + 19293352215 *\n2. Ouça as instruções\n3. Pressione 1\n4. Complete sua prática de falar\n5. Desligue o telefone quando terminar.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3328,
       "label": "audio_instructions_full_wa",
       "translation": "🎤 * Use o WhatsApp para enviar seu correio de voz! * 🎤\n\n1. Pressione e segure o microfone ↘\n2. Comece a falar.\n3. Quando terminar, remova o dedo do microfone.\n4. Sua voz será enviada automaticamente.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3305,
-      "label": "drill_complete_likert",
-      "translation": "En una escala del 1 al 10, ¿qué probabilidades tiene de recomendar esta entrenamiento a un compañero de trabajo?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:46:03Z",
-      "updated_at": "2020-03-10T05:51:04Z",
-      "language": "es"
-    },
-    {
-      "id": 3306,
-      "label": "drill_complete_likert",
-      "translation": "Sur une échelle de 1 à 10, quelle est la probabilité que vous recommandiez cette formation à un collègue?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:46:17Z",
-      "updated_at": "2020-03-10T05:51:38Z",
-      "language": "fr"
-    },
-    {
-      "id": 3308,
-      "label": "likert_1_10_recommend",
-      "translation": "1 = no es probable, 10 = muy probable\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:48:18Z",
-      "updated_at": "2020-03-10T05:52:27Z",
-      "language": "es"
-    },
-    {
-      "id": 3309,
-      "label": "likert_1_10_recommend",
-      "translation": "[1 = peu probable du tout, 10 = extrêmement probable",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:48:29Z",
-      "updated_at": "2020-03-10T05:52:34Z",
-      "language": "fr"
-    },
-    {
-      "id": 3311,
-      "label": "after",
-      "translation": "depois",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3312,
-      "label": "all",
-      "translation": "tudo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3313,
-      "label": "allergic",
-      "translation": "alérgico",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3314,
       "label": "almost_done",
       "translation": "Você está quase pronto! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3315,
-      "label": "amazed",
-      "translation": "atônito",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3316,
       "label": "answer_the_question",
       "translation": "Responde à pergunta.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3317,
-      "label": "answer_the_question_about_the_photo",
-      "translation": "Responda à pergunta sobre a foto.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3318,
-      "label": "anytime",
-      "translation": "em qualquer momento",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3319,
-      "label": "appear",
-      "translation": "aparecer",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3320,
-      "label": "apron",
-      "translation": "avental",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3321,
-      "label": "arrange",
-      "translation": "ordem",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3322,
-      "label": "as_soon_as",
-      "translation": "envergonhado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3323,
-      "label": "ashamed",
-      "translation": "pedir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3324,
-      "label": "ask_for",
-      "translation": "tão pronto como",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3325,
-      "label": "audio_instructions",
-      "translation": "_Use o WhatsApp para enviar sua caixa postal! _ 🎤",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3326,
-      "label": "audio_instructions_full",
-      "translation": "_Usa WhatsApp para enviar tu mensaje de voz!_ 🎤\n\n1. Mantenga presionado el micrófono ↘️\n2. Comienza a hablar.\n3. Cuando termines de hablar, retira el dedo del micrófono",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3331,
       "label": "audio_practice",
       "translation": "🎉 Sua prática!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3302,
       "label": "drill_complete_congrats",
       "translation": "¡Felicidades {{name}}! Tu entrenamiento para hoy ha terminado.\n\nLe haremos saber a {{company}} que lo completó.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:41:07Z",
-      "updated_at": "2020-03-24T02:26:14Z",
       "language": "es"
     },
     {
-      "id": 3303,
       "label": "drill_complete_congrats",
       "translation": "Félicitations {{name}}! La formation est terminée pour aujourd’hui. \n\nNous dirons à {{company}} que vous avez terminé cet exercice.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:41:25Z",
-      "updated_at": "2020-03-24T02:42:18Z",
       "language": "fr"
     },
     {
-      "id": 3270,
       "label": "drill_how_to_practice_3",
       "translation": "Choisissez la meilleure option pour compléter la phrase. \n\nLavez les paumes et le dessus de vos mains. N’oubliez pas de frotter entre [---].\n\na) Vos doigts\nb) Vos orteils\nc) Vos doigts et en-dessous des ongles",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:41:57Z",
-      "updated_at": "2020-03-24T02:47:07Z",
       "language": "fr"
     },
     {
-      "id": 3298,
       "label": "drill_self_assess_3",
       "translation": "(Your answer will be kept private.)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:32:44Z",
-      "updated_at": "2020-03-22T20:53:46Z",
       "language": "en"
     },
     {
-      "id": 3300,
       "label": "drill_self_assess_3",
       "translation": "(Votre réponse sera gardée privée.)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T05:33:42Z",
-      "updated_at": "2020-03-22T20:54:49Z",
       "language": "fr"
     },
     {
-      "id": 3347,
-      "label": "bring",
-      "translation": "trazer",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3348,
-      "label": "broth",
-      "translation": "caldo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3349,
-      "label": "brown",
-      "translation": "castanho",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3350,
-      "label": "burnt",
-      "translation": "queimado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3351,
-      "label": "busy",
-      "translation": "ocupado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3352,
       "label": "bye",
       "translation": "Tenha um bom dia! ☀️",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3353,
-      "label": "can",
-      "translation": "pode",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3354,
-      "label": "cant",
-      "translation": "não posso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3355,
-      "label": "carry",
-      "translation": "levar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3356,
-      "label": "cautious",
-      "translation": "cauteloso",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3357,
       "label": "celebration1",
       "translation": "{{emojis}} You successfully completed today's lesson {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3358,
       "label": "celebration10",
       "translation": "{{emojis}} Lesson complete! Amazing work. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3359,
       "label": "celebration11",
       "translation": "{{emojis}} Your lesson is done! See you next time, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3360,
       "label": "celebration12",
       "translation": "{{emojis}} What a great job. You finished today's lesson! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3361,
       "label": "celebration13",
       "translation": "{{emojis}} Lesson accomplished!!! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3362,
       "label": "celebration14",
       "translation": "{{emojis}} Lesson complete! Your English is getting better everyday! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3363,
       "label": "celebration15",
       "translation": "{{emojis}} Yeehaw!!! Your lesson is complete! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3364,
       "label": "celebration2",
       "translation": "{{emojis}} Excellent work today, {{name}}. Keep it up! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3365,
       "label": "celebration3",
       "translation": "{{emojis}} You did a great job today, {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3366,
       "label": "celebration4",
       "translation": "{{emojis}} Wow! Impressive effort today, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3367,
       "label": "celebration5",
       "translation": "{{emojis}} Today's lesson is done. Outstanding! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3368,
       "label": "celebration6",
       "translation": "{{emojis}} Woohoo! You finished today's lesson. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3369,
       "label": "celebration7",
       "translation": "{{emojis}} Your lesson is complete. Terrific job, {{name}}! ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3370,
       "label": "celebration8",
       "translation": "{{emojis}} Wonderful job, {{name}}! What a great lesson. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3371,
       "label": "celebration9",
       "translation": "{{emojis}} I'm proud of your work today. Thank you for your effort, {{name}}. ~Gabby",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3372,
-      "label": "check_in_question",
-      "translation": "a) minhas aulas são perfeitas\nb) me envie aulas em um horário diferente\nc) me envie lições mais fáceis\nd) envie-me lições mais difíceis\ne) outra coisa (escreva) ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3373,
-      "label": "checking_choices",
-      "translation": "Como estão indo suas lições? Leia as seguintes opções e me diga o que acha.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3374,
-      "label": "cheese",
-      "translation": "queijo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3375,
-      "label": "clean",
-      "translation": "limpar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3376,
-      "label": "clean_out",
-      "translation": "vazio",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3377,
-      "label": "clean_tables",
-      "translation": "mesas limpas",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3378,
-      "label": "clipboard",
-      "translation": "placa de grampo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3379,
-      "label": "clumsy",
-      "translation": "desajeitado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3380,
-      "label": "colander",
-      "translation": "filtro",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3381,
-      "label": "come",
-      "translation": "chegar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3382,
-      "label": "computer",
-      "translation": "computador",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3383,
-      "label": "cook",
-      "translation": "cozinhar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3384,
-      "label": "copper",
-      "translation": "acobreado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3385,
       "label": "correct_audio",
       "translation": "Aqui está a minha pronúncia compará-la com a sua.\n\n🎤 Você pode tentar novamente ou me enviar a palavra * DONE * para concluir.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3386,
       "label": "corrected_answer",
       "translation": "🤖La respuesta correcta es  *{{correct_answer}}*.\n\nVamos para o próximo.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3387,
-      "label": "cough",
-      "translation": "tosse",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3388,
-      "label": "could",
-      "translation": "poderia",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3389,
-      "label": "cover",
-      "translation": "cobertura",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3390,
-      "label": "crab",
-      "translation": "caranguejo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3391,
-      "label": "cross_contamination",
-      "translation": "contaminação cruzada",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3392,
-      "label": "cut",
-      "translation": "cortar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3393,
-      "label": "cut_glove",
-      "translation": "luva de corte",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3394,
-      "label": "dairy",
-      "translation": "laticínios",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3395,
-      "label": "daughter",
-      "translation": "filha",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3396,
-      "label": "dice",
-      "translation": "coceira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3397,
-      "label": "did_you_like_your_first_lesson_what_would_you_like_to_do",
-      "translation": "Você gostou da sua primeira lição? O que você gostaria de fazer?\n\na) baixar para um nível mais difícil\nb) permanecer neste nível",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3398,
-      "label": "different",
-      "translation": "diferente",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3399,
-      "label": "direct_deposit",
-      "translation": "depósito direto",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3400,
-      "label": "dishwasher",
-      "translation": "lava-louças",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3401,
-      "label": "dough",
-      "translation": "massa",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3402,
-      "label": "drain",
-      "translation": "escorrer",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3403,
       "label": "dropoff_ping",
       "translation": "🤖 Olá {{student}}. Ele não completa uma lição há algum tempo. Ainda está lá?",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3404,
       "label": "dropoff_ping_v2",
       "translation": "🤖 Olá {{student}}. Seu gerente {{manager}} Ele me pediu para falar com você. Como estão indo as suas aulas de inglês?",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3405,
-      "label": "during",
-      "translation": "durante",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3406,
-      "label": "each",
-      "translation": "todo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3407,
-      "label": "early",
-      "translation": "cedo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3408,
-      "label": "efficient",
-      "translation": "eficiente",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3409,
-      "label": "eggplant",
-      "translation": "berinjela",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3410,
-      "label": "employee",
-      "translation": "empregado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3411,
       "label": "employer",
       "translation": "teu trabalho",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3412,
-      "label": "empty",
-      "translation": "vazio",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3413,
-      "label": "everyday",
-      "translation": "todos os dias",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3414,
-      "label": "excited",
-      "translation": "excitado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3415,
-      "label": "extra_work",
-      "translation": "trabalho extra",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3416,
-      "label": "family",
-      "translation": "familia",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3417,
-      "label": "fast",
-      "translation": "rápido",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3418,
-      "label": "feel",
-      "translation": "sentir",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3943,
-      "label": "stop",
-      "translation": "terminar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:58:46Z",
-      "updated_at": "2020-03-15T06:58:46Z",
-      "language": "es"
-    },
-    {
-      "id": 3419,
-      "label": "fill_in_the_phrase_with_the_correct_word",
-      "translation": "El Preencha a frase com a palavra correta.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3420,
-      "label": "fill_the_salt_and_pepper",
-      "translation": "encher sal e pimenta",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3421,
-      "label": "filter",
-      "translation": "filtrar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3422,
-      "label": "final_practice",
-      "translation": "Prática final! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3423,
-      "label": "find",
-      "translation": "encontrar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3424,
-      "label": "finished",
-      "translation": "acabar de",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3425,
-      "label": "flat",
-      "translation": "plano",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3426,
-      "label": "flip",
-      "translation": "virar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3427,
-      "label": "follow_the_recipe",
-      "translation": "siga a receita",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3428,
-      "label": "free",
-      "translation": "livre",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3429,
-      "label": "friday",
-      "translation": "sexta-feira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3430,
-      "label": "fruit",
-      "translation": "fruta",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3431,
-      "label": "fry",
-      "translation": "Frite",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3432,
-      "label": "fryer",
-      "translation": "fritadeira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3433,
-      "label": "full",
-      "translation": "cheio",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3434,
-      "label": "garlic",
-      "translation": "alho",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3435,
-      "label": "garnish",
-      "translation": "enfeitar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3436,
       "label": "getting_gabby",
       "translation": "Por favor, aguarde enquanto eu recebo 👩🏻‍🏫 Gabby.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3437,
-      "label": "give",
-      "translation": "dar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3438,
-      "label": "gloves",
-      "translation": "luvas",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3439,
-      "label": "gold",
-      "translation": "a cor do ouro",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3440,
       "label": "grade_soon",
       "translation": "🤖 Recebi sua resposta. Seu professor responderá em breve!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3441,
-      "label": "grate",
-      "translation": "ralar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3442,
-      "label": "grey",
-      "translation": "cinza",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3443,
-      "label": "grill",
-      "translation": "assado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3444,
-      "label": "hairnet",
-      "translation": "hairnet",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3445,
-      "label": "hand_mixer",
-      "translation": "misturador da mão",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3446,
-      "label": "hands",
-      "translation": "mãos",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3447,
-      "label": "have",
-      "translation": "ter",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3448,
-      "label": "have_to",
-      "translation": "tem que",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3449,
-      "label": "health_insurance",
-      "translation": "seguro de saúde",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3450,
-      "label": "heavy",
-      "translation": "pesado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3451,
       "label": "hi",
       "translation": "Oi 👋",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3452,
-      "label": "hold",
-      "translation": "aguentar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3453,
-      "label": "hood",
-      "translation": "exaustor",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3454,
-      "label": "hourly",
-      "translation": "por agora",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3455,
-      "label": "husband",
-      "translation": "marido",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3456,
-      "label": "i_need",
-      "translation": "Preciso",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3457,
-      "label": "ill_be_right_back",
-      "translation": "Já volto.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3458,
-      "label": "immediately",
-      "translation": "imediatamente",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3459,
-      "label": "important",
-      "translation": "importante",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3460,
-      "label": "in_back_of",
-      "translation": "atrás de",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3461,
-      "label": "in_front_of",
-      "translation": "na frente de",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3462,
-      "label": "inch",
-      "translation": "polegadas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3464,
-      "label": "ingredients",
-      "translation": "ingredientes",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3465,
-      "label": "inspection",
-      "translation": "inspeção",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3466,
-      "label": "intake_finished",
-      "translation": "Terminado! 🙌 🎉 😎\n\nVocê receberá sua primeira lição no seu próximo turno! 🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3467,
-      "label": "intake_i_have_some_questions",
-      "translation": "Tenho algumas perguntas para me inscrever!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3468,
-      "label": "intake_orientation_free",
-      "translation": "Este programa é oferecido pelo seu empregador. É grátis! 🍀",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3469,
-      "label": "intake_orientation_shift",
-      "translation": "Você recebe uma lição a cada turno. As aulas levam 5 minutos para serem concluídas. 🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3470,
-      "label": "intake_thanks_lets_start_your_lessons",
-      "translation": "Bem-vindo à sua aula de inglês! 🎉\n\nDigite a palavra * start * para começar.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3471,
-      "label": "intake_what_days_do_you_work",
-      "translation": "* Em que dias você trabalha? * 🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3472,
-      "label": "intake_what_time_do_you_prefer_for_lessons",
-      "translation": "* Durante o seu turno, a que horas você prefere receber suas aulas? * ⌚️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3474,
-      "label": "intake_whats_your_job",
-      "translation": "* Em que cargo você está? *",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3475,
-      "label": "intake_whats_your_level",
-      "translation": "👋 * Qual número descreve o seu nível de inglês no momento? * 🧐\n\n1. Eu não falo nada.\n2. Não falo, mas entendo o básico.\n3. Eu falo e entendo o básico.\n4. Eu falo e entendo frases.\n5. Eu falo, entendo e escrevo frases.\n6. Falo e escrevo quase fluentemente.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3476,
-      "label": "irritated",
-      "translation": "irritado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3477,
-      "label": "is_not_the_same_as",
-      "translation": "não é o mesmo que",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3478,
-      "label": "is_the_phrase_below_correct",
-      "translation": "🤔 A frase a seguir está correta?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3479,
-      "label": "keep_going_one_more_practice",
-      "translation": "Continue indo! Mais uma prática! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3480,
-      "label": "ladder",
-      "translation": "escada",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3481,
-      "label": "ladle",
-      "translation": "concha",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3482,
-      "label": "last_practice",
-      "translation": "Última prática! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3483,
-      "label": "late",
-      "translation": "atrasado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3484,
       "label": "lesson_requires_text",
       "translation": "Esta prática está escrita. Por favor, escreva sua resposta.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3486,
       "label": "lets_move_on",
       "translation": "Ok 👍 Vamos continuar ...",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3487,
-      "label": "lets_practice_write_the_word",
-      "translation": "Vamos praticar! Escreva a palavra",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3488,
-      "label": "lets_practice_write_the_words",
-      "translation": "Vamos praticar! Escreva as palavras",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3489,
-      "label": "lid",
-      "translation": "cobertura",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3490,
-      "label": "light",
-      "translation": "luz",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3491,
-      "label": "line_cook",
-      "translation": "cozinheiro de linha",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3492,
-      "label": "listen",
-      "translation": "ouvir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3944,
-      "label": "stop",
-      "translation": "arrêt",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:59:38Z",
-      "updated_at": "2020-03-15T06:59:38Z",
-      "language": "fr"
-    },
-    {
-      "id": 3946,
-      "label": "clock_in",
-      "translation": "clock in",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:03:18Z",
-      "updated_at": "2020-03-15T07:03:18Z",
-      "language": "en"
-    },
-    {
-      "id": 3473,
       "label": "intake_whats_your_full_name",
       "translation": "Qual é o seu nome completo?\n(nome e sobrenome)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-24T16:42:58Z",
       "language": "pt"
     },
     {
-      "id": 3493,
-      "label": "listen_to_the_audio_then_answer_the_question",
-      "translation": "🔊 Ouça o áudio. Então responda a pergunta.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3494,
-      "label": "listen_to_the_audio_then_fill_in_the_phrase_with_the_correct_word",
-      "translation": "🔊👽 Ouça o áudio. Em seguida, preencha as frases com as palavras corretas.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3495,
-      "label": "listen_to_the_audio_then_fill_in_the_phrases_with_the_correct_words",
-      "translation": "🔊👽 Ouça o áudio. Em seguida, preencha a frase com a palavra correta.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3496,
-      "label": "listen_to_the_audio_write_the_words_in_the_correct_order",
-      "translation": "🔊🔀 Ouça o áudio. Escreva as palavras na ordem correta.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3497,
-      "label": "listen_to_the_audio_write_what_you_hear",
-      "translation": "🔊🎯 Ouça o áudio. Escreva as palavras que ouvir.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3498,
-      "label": "liter",
-      "translation": "litro",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3499,
-      "label": "long_term",
-      "translation": "duradouro",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3500,
-      "label": "look_for",
-      "translation": "procurar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3501,
-      "label": "make_sure",
-      "translation": "tenha certeza",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3502,
-      "label": "mandatory",
-      "translation": "obrigatório",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3504,
-      "label": "melt",
-      "translation": "derreter",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3505,
-      "label": "messy",
-      "translation": "bagunçado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3506,
-      "label": "mixing_bowl",
-      "translation": "tigela",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3507,
-      "label": "monday",
-      "translation": "segunda-feira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3508,
       "label": "more_next_shift",
       "translation": "👉🏼 Mais palavras {{day}}!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3509,
-      "label": "move",
-      "translation": "mover",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3510,
-      "label": "mushrooms",
-      "translation": "cogumelos",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3511,
       "label": "nano_celebration",
       "translation": "{{audio_word}}! 👍",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3512,
-      "label": "need",
-      "translation": "precisar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3514,
-      "label": "never",
-      "translation": "nunca",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3515,
-      "label": "newspaper",
-      "translation": "jornal",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3516,
-      "label": "now",
-      "translation": "agora",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3517,
-      "label": "nuts",
-      "translation": "nozes",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3518,
-      "label": "often",
-      "translation": "frequentemente",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3519,
-      "label": "ok",
-      "translation": "ok",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3520,
       "label": "ok_thanks",
       "translation": "🤖 OK, obrigado. 👍",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3521,
-      "label": "on_leave",
-      "translation": "de licença",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3522,
-      "label": "on_time",
-      "translation": "a tempo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3523,
-      "label": "on_top_of",
-      "translation": "em cima de",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3524,
-      "label": "one_more_practice",
-      "translation": "Mais uma prática! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3525,
-      "label": "order",
-      "translation": "ordem",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3526,
-      "label": "ounce",
-      "translation": "onça",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3527,
-      "label": "oven",
-      "translation": "forno",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3528,
-      "label": "overcooked",
-      "translation": "recozido",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3529,
-      "label": "oyster",
-      "translation": "ostra",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3530,
-      "label": "pan",
-      "translation": "frigideira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3531,
-      "label": "parsley",
-      "translation": "salsa",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3532,
-      "label": "pay_attention",
-      "translation": "prestar atenção",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3533,
-      "label": "peel",
-      "translation": "descascar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3534,
-      "label": "peeler",
-      "translation": "descascador",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3535,
-      "label": "peppers",
-      "translation": "pimentas",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3536,
       "label": "pick_an_option",
       "translation": "Envie-me um número entre 1 e 5.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3537,
-      "label": "poach",
-      "translation": "caça furtiva",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3538,
-      "label": "polish_glasses",
-      "translation": "óculos polonês",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3539,
-      "label": "pot",
-      "translation": "pote",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3540,
-      "label": "potatoes",
-      "translation": "batatas",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3541,
-      "label": "pound",
-      "translation": "libra",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3542,
-      "label": "pour",
-      "translation": "derramar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3543,
-      "label": "practice",
-      "translation": "praticar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3544,
       "label": "practice_again",
       "translation": "Ok! Tente sua prática novamente.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3545,
-      "label": "practice_speaking",
-      "translation": "🗣 Pratique falar!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3546,
-      "label": "practice_speaking_complete_the_dialog_below",
-      "translation": "🗣 Pratique falar! Complete o seguinte diálogo.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3547,
-      "label": "practice_speaking_fill_in_the_sentence_then_send_me_audio",
-      "translation": "🗣 Talk Practice! Preencha a frase. Então me envie áudio.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3548,
-      "label": "practice_speaking_say_the_phrase_below",
-      "translation": "🗣 Pratique falar! Diga a seguinte frase.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3549,
-      "label": "practice_speaking_say_the_word_below",
-      "translation": "🗣 Pratique falar! Diga a próxima palavra 3 vezes.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3550,
-      "label": "prep_cook",
-      "translation": "chef de preparação",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3551,
-      "label": "prepare",
-      "translation": "preparar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3552,
-      "label": "previously",
-      "translation": "antes",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3553,
-      "label": "printer",
-      "translation": "impressora",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3554,
-      "label": "promotion",
-      "translation": "promoção",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3555,
-      "label": "put",
-      "translation": "colocar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3556,
-      "label": "quart",
-      "translation": "quart",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3557,
-      "label": "quart_container",
-      "translation": "quart container",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3558,
-      "label": "raise",
-      "translation": "aumento de salário",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3559,
       "label": "ready",
       "translation": "muito especial",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3560,
       "label": "ready_for_audio",
       "translation": "🤖 Olá, {{student}}! Obrigado por concluir sua prática de falar. Deseja ouvir o áudio que gravou?\na. sim\nb. não",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3561,
       "label": "ready_for_lesson",
       "translation": "🤖 Olá {{student}}. Sua próxima lição é: * {{lesson_label}} *. Você está pronto para fazer isso? a) sim b) não",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3562,
       "label": "ready_for_wotd",
       "translation": "Olá {{student}}. Sua palavra do dia é * {{lesson_label}} *. Digite \"SIM\" para ouvir o áudio.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3563,
-      "label": "really",
-      "translation": "muito",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3564,
-      "label": "recall",
-      "translation": "recuar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3565,
-      "label": "receipt_paper",
-      "translation": "papel de recibo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3566,
-      "label": "red",
-      "translation": "vermelho",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3567,
-      "label": "refrigerator",
-      "translation": "refrigerador",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3945,
-      "label": "stop",
-      "translation": "terminar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:00:22Z",
-      "updated_at": "2020-03-15T07:00:22Z",
-      "language": "pt"
-    },
-    {
-      "id": 3951,
-      "label": "clock_out",
-      "translation": "clock out",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:11:39Z",
-      "updated_at": "2020-03-15T07:11:39Z",
-      "language": "en"
-    },
-    {
-      "id": 3568,
       "label": "reminder_msg",
       "translation": "👩🏻‍🏫 Você concluiu {{completed_activities}} de {{total_activities}} atividades nesta lição.\n\nEnvie-me a palavra * DONE * se terminar hoje. ",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3569,
       "label": "reschedule",
       "translation": "Ok! 🗓️ Estou programando sua lição para {{day}}.\n\nSe você quiser fazer isso antes, envie-me a palavra * READY *.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3570,
-      "label": "rice",
-      "translation": "arroz",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3571,
-      "label": "right",
-      "translation": "correto",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3572,
-      "label": "right_now",
-      "translation": "agora mesmo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3573,
-      "label": "roll_out",
-      "translation": "rolo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3574,
-      "label": "rolling_pin",
-      "translation": "estender com o rolo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3575,
-      "label": "safe_temperatures",
-      "translation": "temperaturas seguras",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3576,
-      "label": "salary",
-      "translation": "salário",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3577,
-      "label": "same",
-      "translation": "o mesmo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3578,
-      "label": "sanitary",
-      "translation": "sanitário",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3579,
-      "label": "saturday",
-      "translation": "sábado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3580,
-      "label": "sauce",
-      "translation": "molho",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3581,
-      "label": "saute",
-      "translation": "pular",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3582,
-      "label": "scale",
-      "translation": "equilibrar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3583,
       "label": "self_eval",
       "translation": "Numa escala de 1 a 5, como você se sentiu com esta lição?\n5 = 🤩 adorei\n4 = 😁 gostei\n3 = 😕 Gostei mais ou menos\n2 = 😟 não gostei\n1 = 🤬 Eu a odiava\n",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3584,
-      "label": "serve",
-      "translation": "servir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3585,
-      "label": "shake",
-      "translation": "bater",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3586,
-      "label": "shellfish",
-      "translation": "frutos do mar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3587,
-      "label": "shift",
-      "translation": "turno de trabalho",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3588,
-      "label": "short_term",
-      "translation": "a curto prazo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3589,
-      "label": "should",
-      "translation": "deveria",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3590,
-      "label": "show_up",
-      "translation": "aparecer",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3591,
-      "label": "shrimp",
-      "translation": "camarão",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3592,
-      "label": "shy",
-      "translation": "tímido",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3593,
-      "label": "sick",
-      "translation": "doente",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3594,
-      "label": "sift",
-      "translation": "peneirar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3595,
-      "label": "silver",
-      "translation": "banhado a prata",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3596,
-      "label": "silverware_rollup",
-      "translation": "rolo coberto",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3597,
-      "label": "simmer",
-      "translation": "ferver",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3598,
-      "label": "since",
-      "translation": "de",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3599,
-      "label": "sink",
-      "translation": "lavatório",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3600,
-      "label": "slice",
-      "translation": "fatia",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3601,
-      "label": "slow",
-      "translation": "lento",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3602,
-      "label": "smoke_break",
-      "translation": "pausa para fumar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3603,
-      "label": "sneeze",
-      "translation": "espirrar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3604,
-      "label": "so",
-      "translation": "assim que",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3605,
-      "label": "soap",
-      "translation": "sabão",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3606,
-      "label": "sometimes",
-      "translation": "as vezes",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3607,
-      "label": "son",
-      "translation": "filho",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3608,
-      "label": "soon",
-      "translation": "em breve",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3609,
-      "label": "soy",
-      "translation": "soja",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3610,
-      "label": "spot",
-      "translation": "aguentar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3611,
-      "label": "stack",
-      "translation": "empilhar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3612,
-      "label": "staff",
-      "translation": "pessoal",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3613,
-      "label": "stand",
-      "translation": "levante-se",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3614,
-      "label": "stand_mixer",
-      "translation": "misturador permanente",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3615,
-      "label": "start",
-      "translation": "iniciar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3616,
-      "label": "steam",
-      "translation": "vapor",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3617,
-      "label": "still",
-      "translation": "ainda",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3618,
-      "label": "stir",
-      "translation": "mexer",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3619,
-      "label": "store",
-      "translation": "salvar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3620,
-      "label": "stove",
-      "translation": "fogão",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3621,
-      "label": "sunday",
-      "translation": "domingo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3622,
-      "label": "take_a_break",
-      "translation": "descansar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3623,
-      "label": "take_out_container",
-      "translation": "recipiente para viagem",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3624,
-      "label": "tape",
-      "translation": "fita",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3625,
-      "label": "temporary",
-      "translation": "temporário",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3626,
-      "label": "tenure",
-      "translation": "ocupação",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3627,
       "label": "text_done",
       "translation": "Entendi, 👍  envie-me a palavra * DONE * para terminar.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3628,
       "label": "thank_you",
       "translation": "Obrigado!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3629,
-      "label": "that",
-      "translation": "esse",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3630,
-      "label": "there_are",
-      "translation": "existem",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3631,
-      "label": "there_is",
-      "translation": "existem",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3632,
-      "label": "thermometer",
-      "translation": "termômetro",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3633,
-      "label": "these",
-      "translation": "estes",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3634,
-      "label": "thick",
-      "translation": "grosso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3635,
-      "label": "this",
-      "translation": "isto",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3636,
-      "label": "thursday",
-      "translation": "quinta-feira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3637,
       "label": "till_tomorrow",
       "translation": "🤖 * Bom trabalho! Mais lições {{day}} * 🎉⭐️⭐️⭐️",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3638,
-      "label": "time_off",
-      "translation": "tempo livre",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3639,
-      "label": "today",
-      "translation": "hoje",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3640,
-      "label": "today_lesson_is",
-      "translation": "A lição de hoje é",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3641,
-      "label": "tomatoes",
-      "translation": "tomates",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3642,
-      "label": "tomorrow",
-      "translation": "Manhã",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3643,
-      "label": "tongs",
-      "translation": "pinças",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3644,
-      "label": "towel",
-      "translation": "trapo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3645,
-      "label": "training",
-      "translation": "treinamento",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3646,
       "label": "transfer1",
       "translation": "* Lição de casa *: Agora, volte ao trabalho e pratique as palavras de hoje.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3647,
       "label": "transfer10",
       "translation": "* Lição de casa *: Ok! Agora, seja corajoso e tente falar um pouco de inglês com seu gerente.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3648,
       "label": "transfer11",
       "translation": "* Lição de casa *: Agora, eu desafio você a praticar inglês no trabalho!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3649,
       "label": "transfer12",
       "translation": "* Lição de casa *: Você disse ao seu gerente que terminou sua lição? Vá conversar com eles, se estiverem disponíveis, e diga quais palavras você aprendeu hoje!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3650,
       "label": "transfer13",
       "translation": "* Lição de casa *: Agora, converse com um amigo no trabalho sobre sua lição. Eles sabem as palavras que você aprendeu hoje?",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3651,
       "label": "transfer14",
       "translation": "* Lição de casa *: Ok. Aqui estão alguns conselhos para ajudá-lo a falar. Soletre as palavras que aprendeu hoje com sua voz. Diga a letra em inglês!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3652,
       "label": "transfer15",
       "translation": "* Lição de casa *: Seja corajoso e pratique falar! Escreva as palavras que aprendeu hoje em sua lista ou programação de preparação.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3653,
       "label": "transfer2",
       "translation": "* Lição de casa *: Ok. Tente praticar sua palavra 3 vezes com um amigo hoje.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3654,
       "label": "transfer3",
       "translation": "* Lição de casa *: Agora, pratique em seu trabalho. Converse com seu gerente sobre o que você aprendeu hoje!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3655,
       "label": "transfer4",
       "translation": "* Lição de casa *: Agora tente isso. Enquanto trabalha hoje, ouça as palavras que acabou de aprender.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3656,
       "label": "transfer5",
       "translation": "* Trabalho de casa *: para mais prática, diga as palavras que aprendeu no espelho 3 vezes.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3657,
       "label": "transfer6",
       "translation": "* Lição de casa *: Ok! Agora pratique com um colega de trabalho para continuar melhorando.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3658,
       "label": "transfer7",
       "translation": "* Lição de casa *: a melhor maneira de acelerar suas habilidades de falar é usar o que aprendeu. Vá conversar com um colega de trabalho e pratique suas palavras.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3659,
       "label": "transfer8",
       "translation": "* Trabalho de casa *: Aqui estão alguns conselhos! Escreva as novas palavras que aprendeu em um pedaço de papel, cole-o no armário e pratique sempre que trocar seu uniforme!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3660,
       "label": "transfer9",
       "translation": "* Trabalho de casa *: para melhorar sua pronúncia, é bom que você ouça enquanto fala inglês. Para praticar mais, ouça a mensagem de voz que você enviou três vezes.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3661,
-      "label": "trash",
-      "translation": "lixo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3662,
       "label": "try_again_done",
       "translation": "🎤 Você pode tentar novamente ou me enviar a palavra * DONE * para concluir.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3663,
       "label": "try_again_next",
       "translation": "🎤 Você pode tentar novamente ou me enviar a palavra * NEXT * para ouvir minha pronúncia.",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3664,
-      "label": "tuesday",
-      "translation": "Terça-feira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3665,
-      "label": "tuna",
-      "translation": "atum",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3666,
-      "label": "unconscious",
-      "translation": "inconsciente",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3667,
-      "label": "unfortunately",
-      "translation": "infelizmente",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3668,
-      "label": "uniform",
-      "translation": "uniforme",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3669,
-      "label": "unless",
-      "translation": "a menos que",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3670,
-      "label": "until",
-      "translation": "até",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3671,
-      "label": "usually",
-      "translation": "em geral",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3672,
-      "label": "vacation_days",
-      "translation": "dias de férias",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3673,
-      "label": "vegetables",
-      "translation": "vegetais",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3674,
-      "label": "want",
-      "translation": "quer",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3675,
-      "label": "wash",
-      "translation": "lavar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3676,
-      "label": "water",
-      "translation": "agua",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3677,
-      "label": "wear",
-      "translation": "usar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3678,
-      "label": "wednesday",
-      "translation": "quarta-feira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3679,
-      "label": "weekend",
-      "translation": "fim de semana",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3680,
-      "label": "weigh",
-      "translation": "arrepender",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3684,
-      "label": "what_word_rhymes_with",
-      "translation": "🤓Que palavra rima com",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3686,
-      "label": "wheat_gluten",
-      "translation": "glúten de trigo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3687,
-      "label": "whether",
-      "translation": "sim",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3688,
-      "label": "which_phrase_is_correct",
-      "translation": "🤓 Phrase Qual frase está correta?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3689,
-      "label": "which_phrase_is_true",
-      "translation": "Qual frase é verdadeira?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3690,
-      "label": "whisk",
-      "translation": "batedor",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3691,
-      "label": "white",
-      "translation": "branco",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3692,
-      "label": "wife",
-      "translation": "marido",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3693,
-      "label": "work",
-      "translation": "trabalhar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3694,
-      "label": "worried",
-      "translation": "preocupado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3695,
       "label": "wotd_corrected_answer",
       "translation": "🤖 A resposta correta é * {{correct_answer}} * *.\n\nEnvie-me * MORE * para receber outro. ",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3696,
       "label": "wotd_more_correct_answer",
       "translation": "🤖 {{happy_word}}! Você está correto!\n{{emojis}}\nEnvie-me * MORE * para receber outro. ",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3697,
       "label": "wotd_tomorrow_correct_answer",
       "translation": "🤖 {{happy_word}}! Você está correto!\n{{emojis}}\nMais palavras {{day}}! ",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3698,
-      "label": "would_do",
-      "translation": "faria",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3699,
-      "label": "write_the_words_below_in_the_correct_order",
-      "translation": "🔀 Escreva as seguintes palavras na ordem correta.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3700,
-      "label": "wrong",
-      "translation": "errado",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3701,
-      "label": "yellow",
-      "translation": "amarelo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3702,
-      "label": "yesterday",
-      "translation": "ontem",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3703,
-      "label": "yet",
-      "translation": "ainda",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3704,
-      "label": "you_are_close_to_the_end",
-      "translation": "Você está perto do fim! ⬇️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3705,
       "label": "you_are_welcome",
       "translation": "De nada 😊",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3706,
-      "label": "you_will_receive_your_5_minute_lessons_each_shift",
-      "translation": "Você receberá aulas de 5 minutos a cada turno. Complete-os durante o seu turno. 🗓",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3707,
-      "label": "your",
-      "translation": "seu \/ seus",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3708,
-      "label": "your_word_of_the_day_is",
-      "translation": "Sua palavra do dia é",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3709,
-      "label": "zucchini",
-      "translation": "abobrinha",
-      "translation_type": "vocab",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3710,
-      "label": "choose_the_correct_answer",
-      "translation": "Elija la mejor respuesta.\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T21:25:54Z",
-      "updated_at": "2020-03-10T21:25:54Z",
-      "language": "es"
-    },
-    {
-      "id": 3711,
-      "label": "choose_the_correct_answer",
-      "translation": "Choisissez la meilleure réponse.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T21:26:06Z",
-      "updated_at": "2020-03-10T21:26:06Z",
-      "language": "fr"
-    },
-    {
-      "id": 3683,
-      "label": "what_does_this_word_mean",
-      "translation": "🤓 O que a palavra significa?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-11T21:41:25Z",
-      "language": "pt"
-    },
-    {
-      "id": 3712,
-      "label": "fill_in_the_phrase_with_the_correct_words",
-      "translation": "Choose the best option to fill in the space. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T21:27:05Z",
-      "updated_at": "2020-03-10T21:28:20Z",
-      "language": "en"
-    },
-    {
-      "id": 3681,
-      "label": "what_do_you_hear_in_the_audio",
-      "translation": "🔊 O que você ouve no áudio?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3682,
-      "label": "what_do_you_see_in_the_photo",
-      "translation": "⚡️ O que você vê na foto?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 3714,
-      "label": "fill_in_the_phrase_with_the_correct_words",
-      "translation": "Choisissez la meilleure option pour remplir l'espace.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T21:28:35Z",
-      "updated_at": "2020-03-10T21:28:35Z",
-      "language": "fr"
-    },
-    {
-      "id": 3713,
-      "label": "fill_in_the_phrase_with_the_correct_words",
-      "translation": "Elija la mejor opción para rellenar el espacio.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-10T21:27:19Z",
-      "updated_at": "2020-03-10T21:28:53Z",
-      "language": "es"
-    },
-    {
-      "id": 3717,
       "label": "drill_reminder",
       "translation": "Você está quase pronto! Responda à pergunta anterior.",
-      "translation_type": "system",
-      "created_at": "2020-03-11T19:41:18Z",
-      "updated_at": "2020-03-11T19:41:18Z",
       "language": "pt"
     },
     {
-      "id": 3718,
       "label": "drill_reminder",
       "translation": "Vous avez presque terminé! Répondez à la question ci-dessus.",
-      "translation_type": "system",
-      "created_at": "2020-03-11T19:42:05Z",
-      "updated_at": "2020-03-11T19:42:05Z",
       "language": "fr"
     },
     {
-      "id": 3485,
       "label": "lesson_requires_voice",
       "translation": "{{audio_instructions}}",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3719,
-      "label": "drill_complete_feedback_thanks",
-      "translation": "Thanks for your feedback, ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-12T01:07:14Z",
-      "updated_at": "2020-03-12T01:07:18Z",
-      "language": "en"
-    },
-    {
-      "id": 3720,
-      "label": "drill_complete_feedback_thanks",
-      "translation": "Gracias por tu opinión, ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-12T01:07:39Z",
-      "updated_at": "2020-03-12T01:07:39Z",
-      "language": "es"
-    },
-    {
-      "id": 3721,
-      "label": "drill_complete_feedback_thanks",
-      "translation": "Merci pour votre avis,\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-12T01:07:57Z",
-      "updated_at": "2020-03-12T01:07:57Z",
-      "language": "fr"
-    },
-    {
-      "id": 3722,
       "label": "intake_ping",
       "translation": "¡Hola! Tu gerente {{manager}} en {{company}} te nominó para la clase de inglés. ¿Te gustaría saber más? 😃",
-      "translation_type": "system",
-      "created_at": "2020-03-12T01:17:05Z",
-      "updated_at": "2020-03-12T01:17:05Z",
       "language": "es"
     },
     {
-      "id": 3723,
       "label": "intake_ping",
       "translation": "Salut! Votre responsable {{manager}} à {{company}} vous a nommé pour le cours d'anglais. Souhaitez-vous en savoir plus? 😃",
-      "translation_type": "system",
-      "created_at": "2020-03-12T01:18:04Z",
-      "updated_at": "2020-03-12T01:18:04Z",
       "language": "fr"
     },
     {
-      "id": 3724,
       "label": "intake_ping",
       "translation": "Hi {{name}}. Your manager {{manager}} at {{company}} nominated you for English class. Would you like to take the class?",
-      "translation_type": "system",
-      "created_at": "2020-03-12T01:22:16Z",
-      "updated_at": "2020-03-12T01:22:16Z",
       "language": "en"
     },
     {
-      "id": 3733,
-      "label": "tablespoon",
-      "translation": "colher de sopa\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T04:54:24Z",
-      "updated_at": "2020-03-14T04:54:30Z",
-      "language": "pt"
-    },
-    {
-      "id": 3734,
-      "label": "quarter",
-      "translation": "quarter",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:11:31Z",
-      "updated_at": "2020-03-14T05:11:31Z",
-      "language": "en"
-    },
-    {
-      "id": 3725,
       "label": "intake_ping",
       "translation": "Olá! Seu gerente {{manager}} em {{company}} o nomeou para a aula de inglês. Gostaria de saber mais?😃",
-      "translation_type": "system",
-      "created_at": "2020-03-12T01:22:33Z",
-      "updated_at": "2020-03-12T01:22:33Z",
       "language": "pt"
     },
     {
-      "id": 3735,
-      "label": "quarter",
-      "translation": "cuarto",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:12:31Z",
-      "updated_at": "2020-03-14T05:12:31Z",
-      "language": "es"
-    },
-    {
-      "id": 3726,
-      "label": "update_test_03132020",
-      "translation": "{{company}} update: Marta will only be open for lunch on Thursday, March 19th. Call time for all employees will be 10am. \n\n[created: 3\/12\/20]",
-      "translation_type": "lesson",
-      "created_at": "2020-03-13T22:51:19Z",
-      "updated_at": "2020-03-13T22:51:51Z",
-      "language": "en"
-    },
-    {
-      "id": 3736,
-      "label": "quarter",
-      "translation": "quatrième",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:13:32Z",
-      "updated_at": "2020-03-14T05:13:32Z",
-      "language": "fr"
-    },
-    {
-      "id": 3727,
-      "label": "update_test_03132020",
-      "translation": "Actualización de {{company}}: Marta solo estará abierta para el almuerzo el jueves 19 de marzo. El tiempo de llegado para todos los empleados será a las 10 am.\n\n[created: 3\/13\/20]",
-      "translation_type": "lesson",
-      "created_at": "2020-03-13T22:52:21Z",
-      "updated_at": "2020-03-13T22:52:59Z",
-      "language": "es"
-    },
-    {
-      "id": 3728,
-      "label": "update_test_03132020",
-      "translation": "Mise à jour {{Company}}: Marta sera uniquement ouverte pour le déjeuner le jeudi 19 mars. L'heure d'arrivée pour tous les employés sera à 10 heures.\n\n[created: 3\/13\/20]",
-      "translation_type": "lesson",
-      "created_at": "2020-03-13T22:53:19Z",
-      "updated_at": "2020-03-13T22:53:19Z",
-      "language": "fr"
-    },
-    {
-      "id": 3730,
-      "label": "tablespoon",
-      "translation": "tablespoon",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T04:09:46Z",
-      "updated_at": "2020-03-14T04:17:29Z",
-      "language": "en"
-    },
-    {
-      "id": 3731,
-      "label": "tablespoon",
-      "translation": "cucharada",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T04:10:38Z",
-      "updated_at": "2020-03-14T04:17:51Z",
-      "language": "es"
-    },
-    {
-      "id": 3732,
-      "label": "tablespoon",
-      "translation": "cuillère à soupe",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T04:51:59Z",
-      "updated_at": "2020-03-14T04:51:59Z",
-      "language": "fr"
-    },
-    {
-      "id": 3737,
-      "label": "quarter",
-      "translation": "quarto",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:14:57Z",
-      "updated_at": "2020-03-14T05:14:57Z",
-      "language": "pt"
-    },
-    {
-      "id": 3738,
-      "label": "half",
-      "translation": "half",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:25:36Z",
-      "updated_at": "2020-03-14T05:25:36Z",
-      "language": "en"
-    },
-    {
-      "id": 3739,
-      "label": "half",
-      "translation": "mitad",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:27:14Z",
-      "updated_at": "2020-03-14T05:28:38Z",
-      "language": "es"
-    },
-    {
-      "id": 3740,
-      "label": "half",
-      "translation": "la moitié",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:29:13Z",
-      "updated_at": "2020-03-14T05:29:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 3741,
-      "label": "half",
-      "translation": "metade",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:29:44Z",
-      "updated_at": "2020-03-14T05:29:44Z",
-      "language": "pt"
-    },
-    {
-      "id": 3742,
-      "label": "cup",
-      "translation": "cup",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:54:48Z",
-      "updated_at": "2020-03-14T05:54:48Z",
-      "language": "en"
-    },
-    {
-      "id": 3743,
-      "label": "cup",
-      "translation": "taza",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:54:55Z",
-      "updated_at": "2020-03-14T05:54:55Z",
-      "language": "es"
-    },
-    {
-      "id": 3744,
-      "label": "cup",
-      "translation": "tasse",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:55:34Z",
-      "updated_at": "2020-03-14T05:55:34Z",
-      "language": "fr"
-    },
-    {
-      "id": 3745,
-      "label": "cup",
-      "translation": "caneca\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T05:56:14Z",
-      "updated_at": "2020-03-14T05:56:14Z",
-      "language": "pt"
-    },
-    {
-      "id": 3746,
-      "label": "dangerous",
-      "translation": "dangerous",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:18:56Z",
-      "updated_at": "2020-03-14T06:31:51Z",
-      "language": "en"
-    },
-    {
-      "id": 3760,
-      "label": "ventilation",
-      "translation": "ventilation",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:29:20Z",
-      "updated_at": "2020-03-14T06:33:42Z",
-      "language": "fr"
-    },
-    {
-      "id": 3761,
-      "label": "ventilation",
-      "translation": "ventilação",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T06:29:45Z",
-      "updated_at": "2020-03-14T06:29:45Z",
-      "language": "pt"
-    },
-    {
-      "id": 3762,
-      "label": "electrical_cord",
-      "translation": "electrical cord",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:29:57Z",
-      "updated_at": "2020-03-14T06:31:28Z",
-      "language": "en"
-    },
-    {
-      "id": 3750,
-      "label": "dilute",
-      "translation": "dilute",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:20:56Z",
-      "updated_at": "2020-03-14T06:32:01Z",
-      "language": "en"
-    },
-    {
-      "id": 3751,
-      "label": "dilute",
-      "translation": "diluir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:21:45Z",
-      "updated_at": "2020-03-14T06:32:07Z",
-      "language": "es"
-    },
-    {
-      "id": 3747,
-      "label": "dangerous",
-      "translation": "peligroso",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:19:28Z",
-      "updated_at": "2020-03-14T06:32:14Z",
-      "language": "es"
-    },
-    {
-      "id": 3748,
-      "label": "dangerous",
-      "translation": "dangereux",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:19:44Z",
-      "updated_at": "2020-03-14T06:32:19Z",
-      "language": "fr"
-    },
-    {
-      "id": 3749,
-      "label": "dangerous",
-      "translation": "perigoso",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:20:46Z",
-      "updated_at": "2020-03-14T06:32:28Z",
-      "language": "pt"
-    },
-    {
-      "id": 3752,
-      "label": "dilute",
-      "translation": "diluer",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:22:11Z",
-      "updated_at": "2020-03-14T06:32:41Z",
-      "language": "fr"
-    },
-    {
-      "id": 3753,
-      "label": "dilute",
-      "translation": "diluir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:22:40Z",
-      "updated_at": "2020-03-14T06:32:45Z",
-      "language": "pt"
-    },
-    {
-      "id": 3754,
-      "label": "greasy_floor",
-      "translation": "greasy floor",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:22:52Z",
-      "updated_at": "2020-03-14T06:32:55Z",
-      "language": "en"
-    },
-    {
-      "id": 3755,
-      "label": "greasy_floor",
-      "translation": "piso grasiento\n",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:23:42Z",
-      "updated_at": "2020-03-14T06:32:59Z",
-      "language": "es"
-    },
-    {
-      "id": 3756,
-      "label": "greasy_floor",
-      "translation": "chão gorduroso\n",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:24:18Z",
-      "updated_at": "2020-03-14T06:33:08Z",
-      "language": "pt"
-    },
-    {
-      "id": 3757,
-      "label": "greasy_floor",
-      "translation": "plancher graisseux",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:27:39Z",
-      "updated_at": "2020-03-14T06:33:19Z",
-      "language": "fr"
-    },
-    {
-      "id": 3758,
-      "label": "ventilation",
-      "translation": "ventilation",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:28:24Z",
-      "updated_at": "2020-03-14T06:33:33Z",
-      "language": "en"
-    },
-    {
-      "id": 3759,
-      "label": "ventilation",
-      "translation": "ventilación",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:29:02Z",
-      "updated_at": "2020-03-14T06:33:37Z",
-      "language": "es"
-    },
-    {
-      "id": 3763,
-      "label": "electrical_cord",
-      "translation": "cable eléctrico",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:30:32Z",
-      "updated_at": "2020-03-14T06:33:51Z",
-      "language": "es"
-    },
-    {
-      "id": 3764,
-      "label": "electrical_cord",
-      "translation": "fil électrique",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:30:56Z",
-      "updated_at": "2020-03-14T06:33:56Z",
-      "language": "fr"
-    },
-    {
-      "id": 3765,
-      "label": "electrical_cord",
-      "translation": "fio elétrico",
-      "translation_type": "vocab",
-      "created_at": "2020-03-14T06:31:12Z",
-      "updated_at": "2020-03-14T06:34:07Z",
-      "language": "pt"
-    },
-    {
-      "id": 3729,
-      "label": "update_test_question",
-      "translation": "update test question",
-      "translation_type": "lesson",
-      "created_at": "2020-03-13T22:54:02Z",
-      "updated_at": "2020-03-14T19:10:12Z",
-      "language": "en"
-    },
-    {
-      "id": 3715,
       "label": "drill_reminder",
       "translation": "You’re almost done! Answer the question above.  ",
-      "translation_type": "system",
-      "created_at": "2020-03-11T19:25:10Z",
-      "updated_at": "2020-03-11T19:25:10Z",
       "language": "en"
     },
     {
-      "id": 3767,
-      "label": "update_ushg",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T22:53:21Z",
-      "updated_at": "2020-03-14T22:53:21Z",
-      "language": "es"
-    },
-    {
-      "id": 3768,
-      "label": "update_ushg",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T22:53:44Z",
-      "updated_at": "2020-03-14T22:53:44Z",
-      "language": "fr"
-    },
-    {
-      "id": 3769,
-      "label": "update_ushg",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T22:53:54Z",
-      "updated_at": "2020-03-14T22:53:54Z",
-      "language": "pt"
-    },
-    {
-      "id": 3770,
-      "label": "update_submission_confirm",
-      "translation": "Your comment\/question has been submitted. Thank you!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T22:59:55Z",
-      "updated_at": "2020-03-14T23:00:16Z",
-      "language": "en"
-    },
-    {
-      "id": 3771,
-      "label": "update_submission_confirm",
-      "translation": "Su comentario\/pregunta ha sido enviado. ¡Gracias!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:00:28Z",
-      "updated_at": "2020-03-14T23:00:28Z",
-      "language": "es"
-    },
-    {
-      "id": 3772,
-      "label": "update_submission_confirm",
-      "translation": "O seu comentário \/ pergunta foi enviado. Obrigada\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:00:34Z",
-      "updated_at": "2020-03-14T23:00:34Z",
-      "language": "pt"
-    },
-    {
-      "id": 3716,
       "label": "drill_reminder",
       "translation": "¡Ya casi terminas! Responde la pregunta anterior.",
-      "translation_type": "system",
-      "created_at": "2020-03-11T19:25:59Z",
-      "updated_at": "2020-03-11T19:25:59Z",
       "language": "es"
     },
     {
-      "id": 3773,
-      "label": "update_submission_confirm",
-      "translation": "Votre commentaire \/ question a été envoyé. Je vous remercie!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:00:43Z",
-      "updated_at": "2020-03-14T23:00:43Z",
-      "language": "fr"
-    },
-    {
-      "id": 2180,
       "label": "need_something",
       "translation": "Nous avons reçu ton message. Je vous remercie!",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "fr"
     },
     {
-      "id": 3513,
       "label": "need_something",
       "translation": "Nós recebemos sua mensagem. Obrigado!",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 3802,
-      "label": "update_raquels_chicken",
-      "translation": "This is a test update for {{company}}. \n\n(created 3\/14\/2020)\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:02:25Z",
-      "updated_at": "2020-03-15T00:02:59Z",
-      "language": "en"
-    },
-    {
-      "id": 3803,
-      "label": "update_raquels_chicken",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:03:05Z",
-      "updated_at": "2020-03-15T00:03:05Z",
-      "language": "es"
-    },
-    {
-      "id": 3804,
-      "label": "update_raquels_chicken",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:03:10Z",
-      "updated_at": "2020-03-15T00:03:10Z",
-      "language": "fr"
-    },
-    {
-      "id": 3805,
-      "label": "update_raquels_chicken",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:03:15Z",
-      "updated_at": "2020-03-15T00:03:15Z",
-      "language": "pt"
-    },
-    {
-      "id": 3776,
-      "label": "update_cava",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:41:57Z",
-      "updated_at": "2020-03-15T01:49:43Z",
-      "language": "en"
-    },
-    {
-      "id": 3777,
-      "label": "update_citarella",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:07Z",
-      "updated_at": "2020-03-15T01:50:26Z",
-      "language": "en"
-    },
-    {
-      "id": 3801,
-      "label": "update_westville",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:44:10Z",
-      "updated_at": "2020-03-15T01:50:39Z",
-      "language": "en"
-    },
-    {
-      "id": 3794,
-      "label": "update_rscms",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:34Z",
-      "updated_at": "2020-03-15T01:51:07Z",
-      "language": "en"
-    },
-    {
-      "id": 3795,
-      "label": "update_sugar",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:43Z",
-      "updated_at": "2020-03-15T01:51:35Z",
-      "language": "en"
-    },
-    {
-      "id": 3798,
-      "label": "update_thesmith",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:56Z",
-      "updated_at": "2020-03-15T01:51:14Z",
-      "language": "en"
-    },
-    {
-      "id": 3791,
-      "label": "update_otg",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:23Z",
-      "updated_at": "2020-03-15T01:51:52Z",
-      "language": "en"
-    },
-    {
-      "id": 3790,
-      "label": "update_north",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:20Z",
-      "updated_at": "2020-03-15T01:52:02Z",
-      "language": "en"
-    },
-    {
-      "id": 3789,
-      "label": "update_noho",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:13Z",
-      "updated_at": "2020-03-15T01:52:17Z",
-      "language": "en"
-    },
-    {
-      "id": 3787,
-      "label": "update_makeitnice",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:03Z",
-      "updated_at": "2020-03-15T01:52:37Z",
-      "language": "en"
-    },
-    {
-      "id": 3786,
-      "label": "update_guck",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:58Z",
-      "updated_at": "2020-03-15T01:52:41Z",
-      "language": "en"
-    },
-    {
-      "id": 3782,
-      "label": "update_fuku",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:42Z",
-      "updated_at": "2020-03-15T01:52:56Z",
-      "language": "en"
-    },
-    {
-      "id": 3785,
-      "label": "update_goodeggs",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:55Z",
-      "updated_at": "2020-03-15T01:53:51Z",
-      "language": "en"
-    },
-    {
-      "id": 3781,
-      "label": "update_dig",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:38Z",
-      "updated_at": "2020-03-15T01:54:03Z",
-      "language": "en"
-    },
-    {
-      "id": 3806,
-      "label": "update_type_a_question",
-      "translation": "Submit an anonymous question or comment here for {{company}}. Your question might inform a future update. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:10:34Z",
-      "updated_at": "2020-03-15T00:12:25Z",
-      "language": "en"
-    },
-    {
-      "id": 3807,
-      "label": "update_type_a_question",
-      "translation": "Envíe una pregunta o comentario anónimo aquí para {{company}}. Su pregunta podría informar a una actualización futura.\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:12:52Z",
-      "updated_at": "2020-03-15T00:12:52Z",
-      "language": "es"
-    },
-    {
-      "id": 3808,
-      "label": "update_type_a_question",
-      "translation": "Soumettez ici une question ou un commentaire anonyme pour {{company}}. Votre question pourrait informer une future mise à jour.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:13:09Z",
-      "updated_at": "2020-03-15T00:13:09Z",
-      "language": "fr"
-    },
-    {
-      "id": 3809,
-      "label": "update_dig",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:22:16Z",
-      "updated_at": "2020-03-15T00:22:16Z",
-      "language": "es"
-    },
-    {
-      "id": 3810,
-      "label": "update_fresh",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:22:23Z",
-      "updated_at": "2020-03-15T00:22:23Z",
-      "language": "es"
-    },
-    {
-      "id": 3811,
-      "label": "update_goodeggs",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:22:36Z",
-      "updated_at": "2020-03-15T00:22:36Z",
-      "language": "es"
-    },
-    {
-      "id": 3812,
-      "label": "update_flik",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:22:42Z",
-      "updated_at": "2020-03-15T00:22:42Z",
-      "language": "es"
-    },
-    {
-      "id": 3813,
-      "label": "update_fuku",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:22:51Z",
-      "updated_at": "2020-03-15T00:22:51Z",
-      "language": "es"
-    },
-    {
-      "id": 3814,
-      "label": "update_cosme",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:22:56Z",
-      "updated_at": "2020-03-15T00:22:56Z",
-      "language": "es"
-    },
-    {
-      "id": 3815,
-      "label": "update_guck",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:23:07Z",
-      "updated_at": "2020-03-15T00:23:07Z",
-      "language": "es"
-    },
-    {
-      "id": 3816,
-      "label": "update_makeitnice",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:23:16Z",
-      "updated_at": "2020-03-15T00:23:16Z",
-      "language": "es"
-    },
-    {
-      "id": 3818,
-      "label": "update_milk",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:23:25Z",
-      "updated_at": "2020-03-15T00:23:25Z",
-      "language": "es"
-    },
-    {
-      "id": 3820,
-      "label": "update_noho",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:23:32Z",
-      "updated_at": "2020-03-15T00:23:32Z",
-      "language": "es"
-    },
-    {
-      "id": 3821,
-      "label": "update_north",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:23:38Z",
-      "updated_at": "2020-03-15T00:23:38Z",
-      "language": "es"
-    },
-    {
-      "id": 3822,
-      "label": "update_otg",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:23:46Z",
-      "updated_at": "2020-03-15T00:23:46Z",
-      "language": "es"
-    },
-    {
-      "id": 3823,
-      "label": "update_paris",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:23:53Z",
-      "updated_at": "2020-03-15T00:23:53Z",
-      "language": "es"
-    },
-    {
-      "id": 3817,
-      "label": "dangling",
-      "translation": "dangling",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:23:24Z",
-      "updated_at": "2020-03-15T00:28:11Z",
-      "language": "en"
-    },
-    {
-      "id": 3819,
-      "label": "dangling",
-      "translation": "colgando",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:23:28Z",
-      "updated_at": "2020-03-15T00:28:24Z",
-      "language": "es"
-    },
-    {
-      "id": 3824,
-      "label": "update_pastini",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:01Z",
-      "updated_at": "2020-03-15T00:24:01Z",
-      "language": "es"
-    },
-    {
-      "id": 3829,
-      "label": "update_thesmith",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:35Z",
-      "updated_at": "2020-03-15T00:24:35Z",
-      "language": "es"
-    },
-    {
-      "id": 3832,
-      "label": "update_compass",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:58Z",
-      "updated_at": "2020-03-15T00:24:58Z",
-      "language": "es"
-    },
-    {
-      "id": 3834,
-      "label": "update_citarella",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:25:11Z",
-      "updated_at": "2020-03-15T00:25:11Z",
-      "language": "es"
-    },
-    {
-      "id": 3854,
-      "label": "update_pastini",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:28:36Z",
-      "updated_at": "2020-03-15T00:28:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 3837,
-      "label": "update_acr",
-      "translation": "Hola equipo,\nSabemos que los tiempos son particularmente difíciles en este momento. Hemos reunido algunos alimentos que estamos poniendo a disposición para que el personal los recoja gratis hoy, jueves 3\/19, por orden de llegada. Visite Aux Kitchen en cualquier momento entre la 1:00 y las 3:00 de la tarde para recoger comida (1519 Brookside Drive).\nPor favor traiga una bolsa \/ caja de su casa para llevar la comida, ya que tenemos muy pocas. Además, si desea huevos, traiga una caja vacía y la llenaremos por usted.\n¡Esperamos verte mañana!\nTeam ACR",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:25:30Z",
-      "updated_at": "2020-03-19T18:36:39Z",
-      "language": "es"
-    },
-    {
-      "id": 3825,
-      "label": "update_rscms",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:07Z",
-      "updated_at": "2020-03-15T00:24:07Z",
-      "language": "es"
-    },
-    {
-      "id": 3826,
-      "label": "update_sugar",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:13Z",
-      "updated_at": "2020-03-15T00:24:13Z",
-      "language": "es"
-    },
-    {
-      "id": 3827,
-      "label": "update_tacombi",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:23Z",
-      "updated_at": "2020-03-15T00:24:23Z",
-      "language": "es"
-    },
-    {
-      "id": 3830,
-      "label": "update_think",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:42Z",
-      "updated_at": "2020-03-15T00:24:42Z",
-      "language": "es"
-    },
-    {
-      "id": 3831,
-      "label": "update_westville",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:48Z",
-      "updated_at": "2020-03-15T00:24:48Z",
-      "language": "es"
-    },
-    {
-      "id": 3833,
-      "label": "update_cornell",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:25:04Z",
-      "updated_at": "2020-03-15T00:25:04Z",
-      "language": "es"
-    },
-    {
-      "id": 3835,
-      "label": "update_cava",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:25:17Z",
-      "updated_at": "2020-03-15T00:25:17Z",
-      "language": "es"
-    },
-    {
-      "id": 3836,
-      "label": "update_bwc",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:25:23Z",
-      "updated_at": "2020-03-15T00:25:23Z",
-      "language": "es"
-    },
-    {
-      "id": 3839,
-      "label": "update_bwc",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:26:54Z",
-      "updated_at": "2020-03-15T00:26:54Z",
-      "language": "fr"
-    },
-    {
-      "id": 3840,
-      "label": "update_cava",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:26:59Z",
-      "updated_at": "2020-03-15T00:26:59Z",
-      "language": "fr"
-    },
-    {
-      "id": 3841,
-      "label": "update_citarella",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:27:05Z",
-      "updated_at": "2020-03-15T00:27:05Z",
-      "language": "fr"
-    },
-    {
-      "id": 3842,
-      "label": "update_cornell",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:27:12Z",
-      "updated_at": "2020-03-15T00:27:12Z",
-      "language": "fr"
-    },
-    {
-      "id": 3843,
-      "label": "dangling",
-      "translation": "pend",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:27:22Z",
-      "updated_at": "2020-03-15T00:27:22Z",
-      "language": "fr"
-    },
-    {
-      "id": 3844,
-      "label": "update_compass",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:27:25Z",
-      "updated_at": "2020-03-15T00:27:25Z",
-      "language": "fr"
-    },
-    {
-      "id": 3845,
-      "label": "update_westville",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:27:31Z",
-      "updated_at": "2020-03-15T00:27:31Z",
-      "language": "fr"
-    },
-    {
-      "id": 3846,
-      "label": "update_think",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:27:36Z",
-      "updated_at": "2020-03-15T00:27:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 3847,
-      "label": "update_thesmith",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:27:42Z",
-      "updated_at": "2020-03-15T00:27:42Z",
-      "language": "fr"
-    },
-    {
-      "id": 3849,
-      "label": "dangling",
-      "translation": "pendurado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:28:04Z",
-      "updated_at": "2020-03-15T00:28:04Z",
-      "language": "pt"
-    },
-    {
-      "id": 3850,
-      "label": "update_tacombi",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:28:05Z",
-      "updated_at": "2020-03-15T00:28:05Z",
-      "language": "fr"
-    },
-    {
-      "id": 3851,
-      "label": "update_sugar",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:28:13Z",
-      "updated_at": "2020-03-15T00:28:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 3852,
-      "label": "update_rscms",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:28:29Z",
-      "updated_at": "2020-03-15T00:28:29Z",
-      "language": "fr"
-    },
-    {
-      "id": 3855,
-      "label": "update_paris",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:28:44Z",
-      "updated_at": "2020-03-15T00:28:44Z",
-      "language": "fr"
-    },
-    {
-      "id": 3856,
-      "label": "update_otg",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:28:50Z",
-      "updated_at": "2020-03-15T00:28:50Z",
-      "language": "fr"
-    },
-    {
-      "id": 3858,
-      "label": "update_north",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:28:59Z",
-      "updated_at": "2020-03-15T00:28:59Z",
-      "language": "fr"
-    },
-    {
-      "id": 3859,
-      "label": "update_noho",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:05Z",
-      "updated_at": "2020-03-15T00:29:05Z",
-      "language": "fr"
-    },
-    {
-      "id": 3860,
-      "label": "update_milk",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:11Z",
-      "updated_at": "2020-03-15T00:29:11Z",
-      "language": "fr"
-    },
-    {
-      "id": 3862,
-      "label": "update_makeitnice",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:17Z",
-      "updated_at": "2020-03-15T00:29:17Z",
-      "language": "fr"
-    },
-    {
-      "id": 3863,
-      "label": "update_guck",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:23Z",
-      "updated_at": "2020-03-15T00:29:23Z",
-      "language": "fr"
-    },
-    {
-      "id": 3864,
-      "label": "update_cosme",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:31Z",
-      "updated_at": "2020-03-15T00:29:31Z",
-      "language": "fr"
-    },
-    {
-      "id": 3853,
-      "label": "hazard",
-      "translation": "hazard",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:28:35Z",
-      "updated_at": "2020-03-15T00:29:37Z",
-      "language": "en"
-    },
-    {
-      "id": 3866,
-      "label": "update_fuku",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:38Z",
-      "updated_at": "2020-03-15T00:29:38Z",
-      "language": "fr"
-    },
-    {
-      "id": 3857,
-      "label": "hazard",
-      "translation": "peligro",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:28:53Z",
-      "updated_at": "2020-03-15T00:29:41Z",
-      "language": "es"
-    },
-    {
-      "id": 3861,
-      "label": "hazard",
-      "translation": "danger",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:29:13Z",
-      "updated_at": "2020-03-15T00:29:46Z",
-      "language": "fr"
-    },
-    {
-      "id": 3867,
-      "label": "update_flik",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:47Z",
-      "updated_at": "2020-03-15T00:29:47Z",
-      "language": "fr"
-    },
-    {
-      "id": 3865,
-      "label": "hazard",
-      "translation": "perigo",
-      "translation_type": "answer",
-      "created_at": "2020-03-15T00:29:31Z",
-      "updated_at": "2020-03-15T00:29:51Z",
-      "language": "pt"
-    },
-    {
-      "id": 3868,
-      "label": "update_goodeggs",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:51Z",
-      "updated_at": "2020-03-15T00:29:51Z",
-      "language": "fr"
-    },
-    {
-      "id": 3869,
-      "label": "update_fresh",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:29:57Z",
-      "updated_at": "2020-03-15T00:29:57Z",
-      "language": "fr"
-    },
-    {
-      "id": 3871,
-      "label": "update_dig",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:30:04Z",
-      "updated_at": "2020-03-15T00:30:04Z",
-      "language": "fr"
-    },
-    {
-      "id": 3870,
-      "label": "leak",
-      "translation": "leak",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:29:59Z",
-      "updated_at": "2020-03-15T00:31:28Z",
-      "language": "en"
-    },
-    {
-      "id": 3872,
-      "label": "leak",
-      "translation": "fuga",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:30:48Z",
-      "updated_at": "2020-03-15T00:31:32Z",
-      "language": "es"
-    },
-    {
-      "id": 3873,
-      "label": "leak",
-      "translation": "fuite",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:31:05Z",
-      "updated_at": "2020-03-15T00:31:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 3874,
-      "label": "leak",
-      "translation": "vazamento",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:31:21Z",
-      "updated_at": "2020-03-15T00:31:42Z",
-      "language": "pt"
-    },
-    {
-      "id": 3875,
-      "label": "trip",
-      "translation": "trip",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:35:58Z",
-      "updated_at": "2020-03-15T00:39:26Z",
-      "language": "en"
-    },
-    {
-      "id": 3876,
-      "label": "trip",
-      "translation": "trip",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:36:07Z",
-      "updated_at": "2020-03-15T00:39:32Z",
-      "language": "en"
-    },
-    {
-      "id": 3877,
-      "label": "trip",
-      "translation": "tropezar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:37:40Z",
-      "updated_at": "2020-03-15T00:39:36Z",
-      "language": "es"
-    },
-    {
-      "id": 3878,
-      "label": "trip",
-      "translation": "trébucher",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:38:27Z",
-      "updated_at": "2020-03-15T00:39:40Z",
-      "language": "fr"
-    },
-    {
-      "id": 3879,
-      "label": "trip",
-      "translation": "tropeçar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:39:21Z",
-      "updated_at": "2020-03-15T00:39:45Z",
-      "language": "pt"
-    },
-    {
-      "id": 3880,
-      "label": "mat",
-      "translation": "mat",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:39:56Z",
-      "updated_at": "2020-03-15T00:43:42Z",
-      "language": "en"
-    },
-    {
-      "id": 3881,
-      "label": "mat",
-      "translation": "estera",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:42:34Z",
-      "updated_at": "2020-03-15T00:43:47Z",
-      "language": "es"
-    },
-    {
-      "id": 3882,
-      "label": "mat",
-      "translation": "tapis",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:43:04Z",
-      "updated_at": "2020-03-15T00:43:52Z",
-      "language": "fr"
-    },
-    {
-      "id": 3883,
-      "label": "mat",
-      "translation": "tapete",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T00:43:36Z",
-      "updated_at": "2020-03-15T00:43:56Z",
-      "language": "pt"
-    },
-    {
-      "id": 3828,
-      "label": "update_grey",
-      "translation": "Próximo banco de alimentos el miércoles 4\/1. Texto Allan en cualquier momento 631-987-2545",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:24:29Z",
-      "updated_at": "2020-03-27T18:25:32Z",
-      "language": "es"
-    },
-    {
-      "id": 3885,
-      "label": "update_sydell",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T01:27:55Z",
-      "updated_at": "2020-03-15T01:27:55Z",
-      "language": "es"
-    },
-    {
-      "id": 3886,
-      "label": "update_sydell",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T01:28:00Z",
-      "updated_at": "2020-03-15T01:28:00Z",
-      "language": "fr"
-    },
-    {
-      "id": 3766,
-      "label": "update_ushg",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T22:52:21Z",
-      "updated_at": "2020-03-15T01:50:00Z",
-      "language": "en"
-    },
-    {
-      "id": 3779,
-      "label": "update_cornell",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:28Z",
-      "updated_at": "2020-03-15T01:50:35Z",
-      "language": "en"
-    },
-    {
-      "id": 3799,
-      "label": "update_think",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:44:03Z",
-      "updated_at": "2020-03-15T01:50:45Z",
-      "language": "en"
-    },
-    {
-      "id": 3796,
-      "label": "update_tacombi",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:47Z",
-      "updated_at": "2020-03-15T01:51:01Z",
-      "language": "en"
-    },
-    {
-      "id": 3778,
-      "label": "update_compass",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:22Z",
-      "updated_at": "2020-03-15T01:51:27Z",
-      "language": "en"
-    },
-    {
-      "id": 3793,
-      "label": "update_pastini",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:29Z",
-      "updated_at": "2020-03-15T01:51:47Z",
-      "language": "en"
-    },
-    {
-      "id": 3792,
-      "label": "update_paris",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:26Z",
-      "updated_at": "2020-03-15T01:52:12Z",
-      "language": "en"
-    },
-    {
-      "id": 3788,
-      "label": "update_milk",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:07Z",
-      "updated_at": "2020-03-15T01:52:22Z",
-      "language": "en"
-    },
-    {
-      "id": 3780,
-      "label": "update_cosme",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:32Z",
-      "updated_at": "2020-03-15T01:52:47Z",
-      "language": "en"
-    },
-    {
-      "id": 3783,
-      "label": "update_flik",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:47Z",
-      "updated_at": "2020-03-15T01:53:15Z",
-      "language": "en"
-    },
-    {
-      "id": 3784,
-      "label": "update_fresh",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:42:51Z",
-      "updated_at": "2020-03-15T01:53:57Z",
-      "language": "en"
-    },
-    {
-      "id": 3884,
-      "label": "update_sydell",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T01:27:31Z",
-      "updated_at": "2020-03-15T01:54:30Z",
-      "language": "en"
-    },
-    {
-      "id": 3887,
-      "label": "can_you_do_me_a_favor",
-      "translation": "can you do me a favor\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:29:26Z",
-      "updated_at": "2020-03-15T04:29:46Z",
-      "language": "en"
-    },
-    {
-      "id": 3888,
-      "label": "can_you_do_me_a_favor",
-      "translation": "¿Me puedes hacer un favor?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:30:33Z",
-      "updated_at": "2020-03-15T04:30:33Z",
-      "language": "es"
-    },
-    {
-      "id": 3889,
-      "label": "can_you_do_me_a_favor",
-      "translation": "Peut tu me rendre un service?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:31:02Z",
-      "updated_at": "2020-03-15T04:31:02Z",
-      "language": "fr"
-    },
-    {
-      "id": 3890,
-      "label": "can_you_do_me_a_favor",
-      "translation": "você pode me fazer um favor?",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:31:15Z",
-      "updated_at": "2020-03-15T04:31:15Z",
-      "language": "pt"
-    },
-    {
-      "id": 3891,
-      "label": "excuse_me",
-      "translation": "excuse me",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:31:54Z",
-      "updated_at": "2020-03-15T04:31:54Z",
-      "language": "en"
-    },
-    {
-      "id": 3892,
-      "label": "excuse_me",
-      "translation": "Perdóneme",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:32:13Z",
-      "updated_at": "2020-03-15T04:32:13Z",
-      "language": "es"
-    },
-    {
-      "id": 3893,
-      "label": "excuse_me",
-      "translation": "Excusez-moi",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:32:25Z",
-      "updated_at": "2020-03-15T04:32:25Z",
-      "language": "fr"
-    },
-    {
-      "id": 3894,
-      "label": "excuse_me",
-      "translation": "Com licença",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:32:39Z",
-      "updated_at": "2020-03-15T04:32:39Z",
-      "language": "pt"
-    },
-    {
-      "id": 3895,
-      "label": "can_i_interrupt",
-      "translation": "Can I interrupt",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:33:02Z",
-      "updated_at": "2020-03-15T04:33:02Z",
-      "language": "en"
-    },
-    {
-      "id": 3896,
-      "label": "can_i_interrupt",
-      "translation": "¿puedo interrumpir?\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:33:39Z",
-      "updated_at": "2020-03-15T04:34:19Z",
-      "language": "es"
-    },
-    {
-      "id": 3897,
-      "label": "can_i_interrupt",
-      "translation": "puis-je vous interrompre?\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:34:44Z",
-      "updated_at": "2020-03-15T04:34:44Z",
-      "language": "fr"
-    },
-    {
-      "id": 3898,
-      "label": "can_i_interrupt",
-      "translation": "posso interromper?\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:34:58Z",
-      "updated_at": "2020-03-15T04:34:58Z",
-      "language": "pt"
-    },
-    {
-      "id": 3899,
-      "label": "im_sorry",
-      "translation": "I'm sorry",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:35:14Z",
-      "updated_at": "2020-03-15T04:35:14Z",
-      "language": "en"
-    },
-    {
-      "id": 3900,
-      "label": "im_sorry",
-      "translation": "Lo siento",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:35:39Z",
-      "updated_at": "2020-03-15T04:35:39Z",
-      "language": "es"
-    },
-    {
-      "id": 3901,
-      "label": "im_sorry",
-      "translation": "Je suis désolé",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:35:48Z",
-      "updated_at": "2020-03-15T04:35:48Z",
-      "language": "fr"
-    },
-    {
-      "id": 3902,
-      "label": "im_sorry",
-      "translation": "Eu sinto Muito",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:36:10Z",
-      "updated_at": "2020-03-15T04:36:10Z",
-      "language": "pt"
-    },
-    {
-      "id": 3903,
-      "label": "i_have_a_suggestion",
-      "translation": "I have a suggestion",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:36:23Z",
-      "updated_at": "2020-03-15T04:36:23Z",
-      "language": "en"
-    },
-    {
-      "id": 3904,
-      "label": "i_have_a_suggestion",
-      "translation": "tengo una sugerencia",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:36:50Z",
-      "updated_at": "2020-03-15T04:36:50Z",
-      "language": "es"
-    },
-    {
-      "id": 3905,
-      "label": "i_have_a_suggestion",
-      "translation": "J'ai une suggestion",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:37:01Z",
-      "updated_at": "2020-03-15T04:37:01Z",
-      "language": "fr"
-    },
-    {
-      "id": 3906,
-      "label": "i_have_a_suggestion",
-      "translation": "Eu tenho uma sugestão",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T04:37:14Z",
-      "updated_at": "2020-03-15T04:37:14Z",
-      "language": "pt"
-    },
-    {
-      "id": 3907,
-      "label": "schedule",
-      "translation": "schedule",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:30:12Z",
-      "updated_at": "2020-03-15T06:30:12Z",
-      "language": "en"
-    },
-    {
-      "id": 3908,
-      "label": "schedule",
-      "translation": "schedule",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:30:23Z",
-      "updated_at": "2020-03-15T06:30:23Z",
-      "language": "en"
-    },
-    {
-      "id": 3909,
-      "label": "schedule",
-      "translation": "horario",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:32:04Z",
-      "updated_at": "2020-03-15T06:32:04Z",
-      "language": "es"
-    },
-    {
-      "id": 3910,
-      "label": "schedule",
-      "translation": "calendrier",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:32:57Z",
-      "updated_at": "2020-03-15T06:32:57Z",
-      "language": "fr"
-    },
-    {
-      "id": 3911,
-      "label": "schedule",
-      "translation": "horário",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:33:14Z",
-      "updated_at": "2020-03-15T06:33:14Z",
-      "language": "pt"
-    },
-    {
-      "id": 3912,
-      "label": "tablet",
-      "translation": "tablet",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:33:56Z",
-      "updated_at": "2020-03-15T06:33:56Z",
-      "language": "en"
-    },
-    {
-      "id": 3913,
-      "label": "tablet",
-      "translation": "tablet",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:34:03Z",
-      "updated_at": "2020-03-15T06:34:03Z",
-      "language": "en"
-    },
-    {
-      "id": 3914,
-      "label": "tablet",
-      "translation": "tableta",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:38:10Z",
-      "updated_at": "2020-03-15T06:38:10Z",
-      "language": "es"
-    },
-    {
-      "id": 3915,
-      "label": "tablet",
-      "translation": "tablette",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:39:41Z",
-      "updated_at": "2020-03-15T06:39:41Z",
-      "language": "fr"
-    },
-    {
-      "id": 3916,
-      "label": "tablet",
-      "translation": "tábua",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:40:56Z",
-      "updated_at": "2020-03-15T06:40:56Z",
-      "language": "pt"
-    },
-    {
-      "id": 3917,
-      "label": "wall",
-      "translation": "wall",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:41:40Z",
-      "updated_at": "2020-03-15T06:41:40Z",
-      "language": "en"
-    },
-    {
-      "id": 3918,
-      "label": "wall",
-      "translation": "wall",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:41:45Z",
-      "updated_at": "2020-03-15T06:41:45Z",
-      "language": "en"
-    },
-    {
-      "id": 3919,
-      "label": "wall",
-      "translation": "pared",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:42:51Z",
-      "updated_at": "2020-03-15T06:42:51Z",
-      "language": "es"
-    },
-    {
-      "id": 3920,
-      "label": "wall",
-      "translation": "mur",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:43:47Z",
-      "updated_at": "2020-03-15T06:43:47Z",
-      "language": "fr"
-    },
-    {
-      "id": 3921,
-      "label": "wall",
-      "translation": "parede",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:44:16Z",
-      "updated_at": "2020-03-15T06:44:16Z",
-      "language": "pt"
-    },
-    {
-      "id": 3922,
-      "label": "clock",
-      "translation": "clock",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:44:39Z",
-      "updated_at": "2020-03-15T06:44:39Z",
-      "language": "en"
-    },
-    {
-      "id": 3923,
-      "label": "clock",
-      "translation": "clock",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:44:44Z",
-      "updated_at": "2020-03-15T06:44:44Z",
-      "language": "en"
-    },
-    {
-      "id": 3924,
-      "label": "clock",
-      "translation": "reloj",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:45:25Z",
-      "updated_at": "2020-03-15T06:45:25Z",
-      "language": "es"
-    },
-    {
-      "id": 3925,
-      "label": "clock",
-      "translation": "l'horloge",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:45:59Z",
-      "updated_at": "2020-03-15T06:45:59Z",
-      "language": "fr"
-    },
-    {
-      "id": 3926,
-      "label": "clock",
-      "translation": "relógio",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:46:32Z",
-      "updated_at": "2020-03-15T06:46:32Z",
-      "language": "pt"
-    },
-    {
-      "id": 3927,
-      "label": "paycheck",
-      "translation": "paycheck",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:47:31Z",
-      "updated_at": "2020-03-15T06:47:31Z",
-      "language": "en"
-    },
-    {
-      "id": 3928,
-      "label": "paycheck",
-      "translation": "paycheck",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:47:43Z",
-      "updated_at": "2020-03-15T06:47:43Z",
-      "language": "en"
-    },
-    {
-      "id": 3929,
-      "label": "paycheck",
-      "translation": "cheque de pago\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:47:49Z",
-      "updated_at": "2020-03-15T06:47:49Z",
-      "language": "es"
-    },
-    {
-      "id": 3930,
-      "label": "paycheck",
-      "translation": "chèque de paie\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:48:30Z",
-      "updated_at": "2020-03-15T06:48:30Z",
-      "language": "fr"
-    },
-    {
-      "id": 3931,
-      "label": "paycheck",
-      "translation": "cheque de salário",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:48:56Z",
-      "updated_at": "2020-03-15T06:48:56Z",
-      "language": "pt"
-    },
-    {
-      "id": 3932,
-      "label": "break",
-      "translation": "break",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:49:21Z",
-      "updated_at": "2020-03-15T06:49:21Z",
-      "language": "en"
-    },
-    {
-      "id": 3933,
-      "label": "break",
-      "translation": "break",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:49:32Z",
-      "updated_at": "2020-03-15T06:49:32Z",
-      "language": "en"
-    },
-    {
-      "id": 3934,
-      "label": "break",
-      "translation": "un descanso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:50:55Z",
-      "updated_at": "2020-03-15T06:50:55Z",
-      "language": "es"
-    },
-    {
-      "id": 3935,
-      "label": "break",
-      "translation": "une pause",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:52:40Z",
-      "updated_at": "2020-03-15T06:53:08Z",
-      "language": "fr"
-    },
-    {
-      "id": 3936,
-      "label": "break",
-      "translation": "pausa",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:54:36Z",
-      "updated_at": "2020-03-15T06:54:36Z",
-      "language": "pt"
-    },
-    {
-      "id": 3937,
-      "label": "take",
-      "translation": "take",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:55:00Z",
-      "updated_at": "2020-03-15T06:55:00Z",
-      "language": "en"
-    },
-    {
-      "id": 3938,
-      "label": "take",
-      "translation": "tomar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:55:31Z",
-      "updated_at": "2020-03-15T06:55:31Z",
-      "language": "es"
-    },
-    {
-      "id": 3939,
-      "label": "take",
-      "translation": "prendre",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:55:57Z",
-      "updated_at": "2020-03-15T06:55:57Z",
-      "language": "fr"
-    },
-    {
-      "id": 3940,
-      "label": "take",
-      "translation": "tomar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:57:02Z",
-      "updated_at": "2020-03-15T06:57:02Z",
-      "language": "pt"
-    },
-    {
-      "id": 3941,
-      "label": "stop",
-      "translation": "stop",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:57:31Z",
-      "updated_at": "2020-03-15T06:57:31Z",
-      "language": "en"
-    },
-    {
-      "id": 3942,
-      "label": "stop",
-      "translation": "stop",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T06:57:38Z",
-      "updated_at": "2020-03-15T06:57:38Z",
-      "language": "en"
-    },
-    {
-      "id": 3948,
-      "label": "clock_in",
-      "translation": "marquez votre entrée\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:07:23Z",
-      "updated_at": "2020-03-15T07:14:46Z",
-      "language": "fr"
-    },
-    {
-      "id": 3950,
-      "label": "clock_out",
-      "translation": "clock out",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:11:34Z",
-      "updated_at": "2020-03-15T07:11:34Z",
-      "language": "en"
-    },
-    {
-      "id": 3949,
-      "label": "clock_in",
-      "translation": "marque sua entrada\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:11:03Z",
-      "updated_at": "2020-03-15T07:14:32Z",
-      "language": "pt"
-    },
-    {
-      "id": 3952,
-      "label": "clock_out",
-      "translation": "marca tu salida",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:15:11Z",
-      "updated_at": "2020-03-15T07:15:11Z",
-      "language": "es"
-    },
-    {
-      "id": 3956,
-      "label": "clean_adj",
-      "translation": "clean adj.",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:16:57Z",
-      "updated_at": "2020-03-15T07:19:48Z",
-      "language": "en"
-    },
-    {
-      "id": 3958,
-      "label": "clean_adj",
-      "translation": "limpio",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:17:31Z",
-      "updated_at": "2020-03-15T07:19:53Z",
-      "language": "es"
-    },
-    {
-      "id": 3962,
-      "label": "not_clean",
-      "translation": "not clean",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:20:46Z",
-      "updated_at": "2020-03-15T07:20:46Z",
-      "language": "en"
-    },
-    {
-      "id": 3982,
-      "label": "faucet",
-      "translation": "grifo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:29:31Z",
-      "updated_at": "2020-03-15T07:29:31Z",
-      "language": "es"
-    },
-    {
-      "id": 3988,
-      "label": "ice",
-      "translation": "gelo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:32:09Z",
-      "updated_at": "2020-03-15T07:32:09Z",
-      "language": "pt"
-    },
-    {
-      "id": 3947,
-      "label": "clock_in",
-      "translation": "marca tu entrada",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:03:24Z",
-      "updated_at": "2020-03-15T07:13:45Z",
-      "language": "es"
-    },
-    {
-      "id": 3955,
-      "label": "clean",
-      "translation": "clean",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:16:32Z",
-      "updated_at": "2020-03-15T07:16:32Z",
-      "language": "en"
-    },
-    {
-      "id": 3970,
-      "label": "dirty",
-      "translation": "sujo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:23:21Z",
-      "updated_at": "2020-03-15T07:23:21Z",
-      "language": "pt"
-    },
-    {
-      "id": 3990,
-      "label": "pitcher",
-      "translation": "pitcher",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:33:02Z",
-      "updated_at": "2020-03-15T07:33:02Z",
-      "language": "en"
-    },
-    {
-      "id": 3953,
-      "label": "clock_out",
-      "translation": "marque sua saída\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:15:49Z",
-      "updated_at": "2020-03-15T07:15:49Z",
-      "language": "pt"
-    },
-    {
-      "id": 3954,
-      "label": "clock_out",
-      "translation": "marquez votre sortie\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:16:03Z",
-      "updated_at": "2020-03-15T07:16:03Z",
-      "language": "fr"
-    },
-    {
-      "id": 3957,
-      "label": "clean_adj",
-      "translation": "clean adj.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:17:04Z",
-      "updated_at": "2020-03-15T07:17:04Z",
-      "language": "en"
-    },
-    {
-      "id": 3960,
-      "label": "clean_adj",
-      "translation": "limpo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:19:26Z",
-      "updated_at": "2020-03-15T07:19:26Z",
-      "language": "pt"
-    },
-    {
-      "id": 3964,
-      "label": "not_clean",
-      "translation": "pas propre",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:21:20Z",
-      "updated_at": "2020-03-15T07:21:20Z",
-      "language": "fr"
-    },
-    {
-      "id": 3969,
-      "label": "dirty",
-      "translation": "sale",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:22:54Z",
-      "updated_at": "2020-03-15T07:22:54Z",
-      "language": "fr"
-    },
-    {
-      "id": 3974,
-      "label": "new",
-      "translation": "nouveau",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:24:41Z",
-      "updated_at": "2020-03-15T07:25:05Z",
-      "language": "fr"
-    },
-    {
-      "id": 3975,
-      "label": "new",
-      "translation": "novo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:24:58Z",
-      "updated_at": "2020-03-15T07:25:09Z",
-      "language": "pt"
-    },
-    {
-      "id": 3978,
-      "label": "old",
-      "translation": "viejo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:26:34Z",
-      "updated_at": "2020-03-15T07:26:34Z",
-      "language": "es"
-    },
-    {
-      "id": 3979,
-      "label": "old",
-      "translation": "vieux",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:27:36Z",
-      "updated_at": "2020-03-15T07:27:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 3986,
-      "label": "ice",
-      "translation": "hielo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:31:36Z",
-      "updated_at": "2020-03-15T07:31:36Z",
-      "language": "es"
-    },
-    {
-      "id": 3959,
-      "label": "clean_adj",
-      "translation": "propre",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:18:49Z",
-      "updated_at": "2020-03-15T07:18:49Z",
-      "language": "fr"
-    },
-    {
-      "id": 3961,
-      "label": "not_clean",
-      "translation": "not clean",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:20:41Z",
-      "updated_at": "2020-03-15T07:20:41Z",
-      "language": "en"
-    },
-    {
-      "id": 3963,
-      "label": "not_clean",
-      "translation": "no limpio",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:21:07Z",
-      "updated_at": "2020-03-15T07:21:07Z",
-      "language": "es"
-    },
-    {
-      "id": 3965,
-      "label": "not_clean",
-      "translation": "não limpo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:21:32Z",
-      "updated_at": "2020-03-15T07:21:32Z",
-      "language": "pt"
-    },
-    {
-      "id": 3966,
-      "label": "dirty",
-      "translation": "dirty",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:22:18Z",
-      "updated_at": "2020-03-15T07:22:18Z",
-      "language": "en"
-    },
-    {
-      "id": 3967,
-      "label": "dirty",
-      "translation": "dirty",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:22:23Z",
-      "updated_at": "2020-03-15T07:22:23Z",
-      "language": "en"
-    },
-    {
-      "id": 3968,
-      "label": "dirty",
-      "translation": "sucio",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:22:37Z",
-      "updated_at": "2020-03-15T07:22:37Z",
-      "language": "es"
-    },
-    {
-      "id": 3971,
-      "label": "new",
-      "translation": "new",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:24:05Z",
-      "updated_at": "2020-03-15T07:24:05Z",
-      "language": "en"
-    },
-    {
-      "id": 3972,
-      "label": "new",
-      "translation": "new",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:24:11Z",
-      "updated_at": "2020-03-15T07:24:11Z",
-      "language": "en"
-    },
-    {
-      "id": 3973,
-      "label": "new",
-      "translation": "nuevo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:24:21Z",
-      "updated_at": "2020-03-15T07:24:21Z",
-      "language": "es"
-    },
-    {
-      "id": 3976,
-      "label": "old",
-      "translation": "old",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:25:42Z",
-      "updated_at": "2020-03-15T07:25:42Z",
-      "language": "en"
-    },
-    {
-      "id": 3977,
-      "label": "old",
-      "translation": "old",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:25:46Z",
-      "updated_at": "2020-03-15T07:25:46Z",
-      "language": "en"
-    },
-    {
-      "id": 3980,
-      "label": "old",
-      "translation": "velho",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:28:11Z",
-      "updated_at": "2020-03-15T07:28:11Z",
-      "language": "pt"
-    },
-    {
-      "id": 3981,
-      "label": "faucet",
-      "translation": "faucet",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:28:58Z",
-      "updated_at": "2020-03-15T07:28:58Z",
-      "language": "en"
-    },
-    {
-      "id": 3983,
-      "label": "faucet",
-      "translation": "robinet\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:30:29Z",
-      "updated_at": "2020-03-15T07:30:39Z",
-      "language": "fr"
-    },
-    {
-      "id": 3984,
-      "label": "faucet",
-      "translation": "torneira",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:31:07Z",
-      "updated_at": "2020-03-15T07:31:07Z",
-      "language": "pt"
-    },
-    {
-      "id": 3985,
-      "label": "ice",
-      "translation": "ice",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:31:24Z",
-      "updated_at": "2020-03-15T07:31:24Z",
-      "language": "en"
-    },
-    {
-      "id": 3987,
-      "label": "ice",
-      "translation": "la glace\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:31:54Z",
-      "updated_at": "2020-03-15T07:31:54Z",
-      "language": "fr"
-    },
-    {
-      "id": 3989,
-      "label": "pitcher",
-      "translation": "pitcher",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:32:58Z",
-      "updated_at": "2020-03-15T07:32:58Z",
-      "language": "en"
-    },
-    {
-      "id": 3991,
-      "label": "pitcher",
-      "translation": "jarrra",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:33:10Z",
-      "updated_at": "2020-03-15T07:33:10Z",
-      "language": "es"
-    },
-    {
-      "id": 3992,
-      "label": "pitcher",
-      "translation": "pichet",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:33:56Z",
-      "updated_at": "2020-03-15T07:33:56Z",
-      "language": "fr"
-    },
-    {
-      "id": 3993,
-      "label": "pitcher",
-      "translation": "jarro",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:34:15Z",
-      "updated_at": "2020-03-15T07:34:15Z",
-      "language": "pt"
-    },
-    {
-      "id": 3994,
-      "label": "tap_water",
-      "translation": "tap water",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:34:48Z",
-      "updated_at": "2020-03-15T07:35:33Z",
-      "language": "en"
-    },
-    {
-      "id": 3995,
-      "label": "tap_water",
-      "translation": "tap water",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:34:53Z",
-      "updated_at": "2020-03-15T07:35:37Z",
-      "language": "en"
-    },
-    {
-      "id": 3996,
-      "label": "tap_water",
-      "translation": "agua del grifo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:34:58Z",
-      "updated_at": "2020-03-15T07:35:41Z",
-      "language": "es"
-    },
-    {
-      "id": 3997,
-      "label": "tap_water",
-      "translation": "eau du robinet\n",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:35:14Z",
-      "updated_at": "2020-03-15T07:35:50Z",
-      "language": "fr"
-    },
-    {
-      "id": 3998,
-      "label": "tap_water",
-      "translation": "água da torneira",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:35:28Z",
-      "updated_at": "2020-03-15T07:35:54Z",
-      "language": "pt"
-    },
-    {
-      "id": 3999,
-      "label": "sparkling",
-      "translation": "sparkling",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:36:38Z",
-      "updated_at": "2020-03-15T07:36:38Z",
-      "language": "en"
-    },
-    {
-      "id": 4000,
-      "label": "sparkling",
-      "translation": "sparkling",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:36:43Z",
-      "updated_at": "2020-03-15T07:36:43Z",
-      "language": "en"
-    },
-    {
-      "id": 4001,
-      "label": "sparkling_water",
-      "translation": "sparkling water",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:36:58Z",
-      "updated_at": "2020-03-15T07:38:18Z",
-      "language": "en"
-    },
-    {
-      "id": 4002,
-      "label": "sparkling_water",
-      "translation": "sparkling water",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:37:04Z",
-      "updated_at": "2020-03-15T07:38:22Z",
-      "language": "en"
-    },
-    {
-      "id": 4003,
-      "label": "sparkling_water",
-      "translation": "agua con gas",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:37:22Z",
-      "updated_at": "2020-03-15T07:38:27Z",
-      "language": "es"
-    },
-    {
-      "id": 4004,
-      "label": "sparkling_water",
-      "translation": "eau gazeuse",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:37:47Z",
-      "updated_at": "2020-03-15T07:38:33Z",
-      "language": "fr"
-    },
-    {
-      "id": 4005,
-      "label": "sparkling_water",
-      "translation": "água com gás\n",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:38:03Z",
-      "updated_at": "2020-03-15T07:38:41Z",
-      "language": "pt"
-    },
-    {
-      "id": 4010,
-      "label": "take_out",
-      "translation": "tirar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:43:33Z",
-      "updated_at": "2020-03-15T07:43:33Z",
-      "language": "pt"
-    },
-    {
-      "id": 4006,
-      "label": "take_out",
-      "translation": "take out",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:41:59Z",
-      "updated_at": "2020-03-15T07:43:40Z",
-      "language": "en"
-    },
-    {
-      "id": 4007,
-      "label": "take_out",
-      "translation": "take out",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:42:05Z",
-      "updated_at": "2020-03-15T07:43:43Z",
-      "language": "en"
-    },
-    {
-      "id": 4008,
-      "label": "take_out",
-      "translation": "sacar",
-      "translation_type": "answer",
-      "created_at": "2020-03-15T07:42:12Z",
-      "updated_at": "2020-03-15T07:43:51Z",
-      "language": "es"
-    },
-    {
-      "id": 4009,
-      "label": "take_out",
-      "translation": "sortir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:43:10Z",
-      "updated_at": "2020-03-15T07:43:56Z",
-      "language": "fr"
-    },
-    {
-      "id": 4014,
-      "label": "open",
-      "translation": "ouvrir",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:45:08Z",
-      "updated_at": "2020-03-15T07:45:08Z",
-      "language": "fr"
-    },
-    {
-      "id": 4015,
-      "label": "open",
-      "translation": "abrir",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:45:27Z",
-      "updated_at": "2020-03-15T07:45:27Z",
-      "language": "pt"
-    },
-    {
-      "id": 4011,
-      "label": "open",
-      "translation": "open",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:44:38Z",
-      "updated_at": "2020-03-15T07:45:37Z",
-      "language": "en"
-    },
-    {
-      "id": 4012,
-      "label": "open",
-      "translation": "open",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:44:45Z",
-      "updated_at": "2020-03-15T07:45:43Z",
-      "language": "en"
-    },
-    {
-      "id": 4013,
-      "label": "open",
-      "translation": "abrir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-15T07:44:51Z",
-      "updated_at": "2020-03-15T07:45:48Z",
-      "language": "es"
-    },
-    {
-      "id": 4016,
-      "label": "close",
-      "translation": "close",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:46:41Z",
-      "updated_at": "2020-03-15T07:46:41Z",
-      "language": "en"
-    },
-    {
-      "id": 4017,
-      "label": "close",
-      "translation": "close",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:46:48Z",
-      "updated_at": "2020-03-15T07:46:48Z",
-      "language": "en"
-    },
-    {
-      "id": 4018,
-      "label": "close",
-      "translation": "cerrar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:46:52Z",
-      "updated_at": "2020-03-15T07:46:52Z",
-      "language": "es"
-    },
-    {
-      "id": 4019,
-      "label": "close",
-      "translation": "fermer",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:47:43Z",
-      "updated_at": "2020-03-15T07:47:43Z",
-      "language": "fr"
-    },
-    {
-      "id": 4020,
-      "label": "close",
-      "translation": "fechar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:48:08Z",
-      "updated_at": "2020-03-15T07:48:08Z",
-      "language": "pt"
-    },
-    {
-      "id": 4021,
-      "label": "organize",
-      "translation": "organize",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:48:34Z",
-      "updated_at": "2020-03-15T07:48:34Z",
-      "language": "en"
-    },
-    {
-      "id": 4022,
-      "label": "organize",
-      "translation": "organize",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:48:42Z",
-      "updated_at": "2020-03-15T07:48:42Z",
-      "language": "en"
-    },
-    {
-      "id": 4023,
-      "label": "organize",
-      "translation": "organizar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:49:02Z",
-      "updated_at": "2020-03-15T07:49:02Z",
-      "language": "es"
-    },
-    {
-      "id": 4024,
-      "label": "organize",
-      "translation": "organiser",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:49:12Z",
-      "updated_at": "2020-03-15T07:49:12Z",
-      "language": "fr"
-    },
-    {
-      "id": 4025,
-      "label": "organize",
-      "translation": "organizar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:49:24Z",
-      "updated_at": "2020-03-15T07:49:24Z",
-      "language": "pt"
-    },
-    {
-      "id": 4026,
-      "label": "sanitize",
-      "translation": "sanitize",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:50:01Z",
-      "updated_at": "2020-03-15T07:50:01Z",
-      "language": "en"
-    },
-    {
-      "id": 4027,
-      "label": "sanitize",
-      "translation": "sanitize",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:50:06Z",
-      "updated_at": "2020-03-15T07:50:06Z",
-      "language": "en"
-    },
-    {
-      "id": 4028,
-      "label": "sanitize",
-      "translation": "desinfectar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:50:12Z",
-      "updated_at": "2020-03-15T07:50:12Z",
-      "language": "es"
-    },
-    {
-      "id": 4029,
-      "label": "sanitize",
-      "translation": "désinfecter",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:50:21Z",
-      "updated_at": "2020-03-15T07:50:21Z",
-      "language": "fr"
-    },
-    {
-      "id": 4030,
-      "label": "sanitize",
-      "translation": "higienizar\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T07:50:30Z",
-      "updated_at": "2020-03-15T07:50:30Z",
-      "language": "pt"
-    },
-    {
-      "id": 3775,
-      "label": "update_bwc",
-      "translation": "This is a test update for {{company}}. Communicate company updates to your workforce. Change them daily. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:41:51Z",
-      "updated_at": "2020-03-16T18:10:46Z",
-      "language": "en"
-    },
-    {
-      "id": 4031,
-      "label": "update_tupelo",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T18:52:11Z",
-      "updated_at": "2020-03-16T19:21:09Z",
-      "language": "en"
-    },
-    {
-      "id": 4032,
-      "label": "update_tupelo",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T19:21:20Z",
-      "updated_at": "2020-03-16T19:21:20Z",
-      "language": "es"
-    },
-    {
-      "id": 4033,
-      "label": "update_tupelo",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T19:21:31Z",
-      "updated_at": "2020-03-16T19:21:31Z",
-      "language": "fr"
-    },
-    {
-      "id": 4034,
-      "label": "update_tupelo",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T19:21:44Z",
-      "updated_at": "2020-03-16T19:21:44Z",
-      "language": "pt"
-    },
-    {
-      "id": 4035,
-      "label": "update_thistle",
-      "translation": "Test update for {{company}}. Dispatch company updates to your workforce. Use the questions your team submits to inform future updates. \n\n(created 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T19:38:06Z",
-      "updated_at": "2020-03-16T19:38:32Z",
-      "language": "en"
-    },
-    {
-      "id": 4036,
-      "label": "update_thistle",
-      "translation": "Aquí esta una prueba de actualización  para {{company}}.\n\n(creado 3\/14\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T19:38:42Z",
-      "updated_at": "2020-03-16T19:38:42Z",
-      "language": "es"
-    },
-    {
-      "id": 4037,
-      "label": "update_thistle",
-      "translation": "Voici un test de mise à niveau pour {{company}}.\n\n(créé le 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T19:38:58Z",
-      "updated_at": "2020-03-16T19:38:58Z",
-      "language": "fr"
-    },
-    {
-      "id": 4038,
-      "label": "update_thistle",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T19:39:04Z",
-      "updated_at": "2020-03-16T19:39:04Z",
-      "language": "pt"
-    },
-    {
-      "id": 4039,
-      "label": "update_cava",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:38:19Z",
-      "updated_at": "2020-03-16T20:38:19Z",
-      "language": "pt"
-    },
-    {
-      "id": 4040,
-      "label": "update_type_a_question",
-      "translation": "Envie uma pergunta ou comentário anônimo aqui para {{company}}. Sua pergunta pode informar uma atualização futura.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:38:59Z",
-      "updated_at": "2020-03-16T20:38:59Z",
-      "language": "pt"
-    },
-    {
-      "id": 4041,
-      "label": "update_citarella",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:39:43Z",
-      "updated_at": "2020-03-16T20:39:43Z",
-      "language": "pt"
-    },
-    {
-      "id": 4042,
-      "label": "update_westville",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:39:48Z",
-      "updated_at": "2020-03-16T20:39:48Z",
-      "language": "pt"
-    },
-    {
-      "id": 4044,
-      "label": "update_rscms",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:08Z",
-      "updated_at": "2020-03-16T20:40:08Z",
-      "language": "pt"
-    },
-    {
-      "id": 4045,
-      "label": "update_thesmith",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:16Z",
-      "updated_at": "2020-03-16T20:40:16Z",
-      "language": "pt"
-    },
-    {
-      "id": 4046,
-      "label": "update_sugar",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:27Z",
-      "updated_at": "2020-03-16T20:40:27Z",
-      "language": "pt"
-    },
-    {
-      "id": 4050,
-      "label": "update_makeitnice",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:54Z",
-      "updated_at": "2020-03-16T20:40:54Z",
-      "language": "pt"
-    },
-    {
-      "id": 4047,
-      "label": "update_otg",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:38Z",
-      "updated_at": "2020-03-16T20:40:38Z",
-      "language": "pt"
-    },
-    {
-      "id": 4052,
-      "label": "update_fuku",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:41:03Z",
-      "updated_at": "2020-03-16T20:41:03Z",
-      "language": "pt"
-    },
-    {
-      "id": 4061,
-      "label": "update_compass",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:27Z",
-      "updated_at": "2020-03-16T20:42:27Z",
-      "language": "pt"
-    },
-    {
-      "id": 4048,
-      "label": "update_north",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:42Z",
-      "updated_at": "2020-03-16T20:40:42Z",
-      "language": "pt"
-    },
-    {
-      "id": 4049,
-      "label": "update_noho",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:47Z",
-      "updated_at": "2020-03-16T20:40:47Z",
-      "language": "pt"
-    },
-    {
-      "id": 4051,
-      "label": "update_guck",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:58Z",
-      "updated_at": "2020-03-16T20:40:58Z",
-      "language": "pt"
-    },
-    {
-      "id": 4053,
-      "label": "update_goodeggs",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:41:10Z",
-      "updated_at": "2020-03-16T20:41:10Z",
-      "language": "pt"
-    },
-    {
-      "id": 4054,
-      "label": "update_dig",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:41:17Z",
-      "updated_at": "2020-03-16T20:41:17Z",
-      "language": "pt"
-    },
-    {
-      "id": 4055,
-      "label": "update_fresh",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:41:35Z",
-      "updated_at": "2020-03-16T20:41:35Z",
-      "language": "pt"
-    },
-    {
-      "id": 4056,
-      "label": "update_flik",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:41:57Z",
-      "updated_at": "2020-03-16T20:41:57Z",
-      "language": "pt"
-    },
-    {
-      "id": 4057,
-      "label": "update_cosme",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:03Z",
-      "updated_at": "2020-03-16T20:42:03Z",
-      "language": "pt"
-    },
-    {
-      "id": 4058,
-      "label": "update_milk",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:11Z",
-      "updated_at": "2020-03-16T20:42:11Z",
-      "language": "pt"
-    },
-    {
-      "id": 4059,
-      "label": "update_paris",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:16Z",
-      "updated_at": "2020-03-16T20:42:16Z",
-      "language": "pt"
-    },
-    {
-      "id": 4060,
-      "label": "update_pastini",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:21Z",
-      "updated_at": "2020-03-16T20:42:21Z",
-      "language": "pt"
-    },
-    {
-      "id": 4066,
-      "label": "update_bwc",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:43:01Z",
-      "updated_at": "2020-03-16T20:43:01Z",
-      "language": "pt"
-    },
-    {
-      "id": 4067,
-      "label": "update_sydell",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:43:10Z",
-      "updated_at": "2020-03-16T20:43:10Z",
-      "language": "pt"
-    },
-    {
-      "id": 4063,
-      "label": "update_tacombi",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:42Z",
-      "updated_at": "2020-03-16T20:42:42Z",
-      "language": "pt"
-    },
-    {
-      "id": 4064,
-      "label": "update_think",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:49Z",
-      "updated_at": "2020-03-16T20:42:49Z",
-      "language": "pt"
-    },
-    {
-      "id": 4065,
-      "label": "update_cornell",
-      "translation": "Aqui está um teste de atualização para {{company}}.\n\n(criado em 14\/03\/2020)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:55Z",
-      "updated_at": "2020-03-16T20:42:55Z",
-      "language": "pt"
-    },
-    {
-      "id": 4086,
       "label": "drill_when_to_practice_1",
       "translation": "Você só precisa lavar as mãos quando elas estiverem visivelmente sujas.\n\na) verdadeiro\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:01:39Z",
-      "updated_at": "2020-03-24T00:17:30Z",
       "language": "pt"
     },
     {
-      "id": 4092,
       "label": "drill_when_to_fact_2",
-      "translation": "FATO: As luvas de uso único (látex \/ nitrilo) são excelentes, mas não substituem a lavagem das mãos. De fato, você deve lavar as mãos antes de colocar as luvas. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:04:51Z",
-      "updated_at": "2020-03-24T07:00:02Z",
+      "translation": "FATO: As luvas de uso único (látex / nitrilo) são excelentes, mas não substituem a lavagem das mãos. De fato, você deve lavar as mãos antes de colocar as luvas. ",
       "language": "pt"
     },
     {
-      "id": 4043,
-      "label": "update_grey",
-      "translation": "Próximo banco de alimentos na quarta-feira, 4\/1. Texto Allan a qualquer momento 631-987-2545",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:40:03Z",
-      "updated_at": "2020-03-27T18:25:55Z",
-      "language": "pt"
-    },
-    {
-      "id": 4070,
-      "label": "likert2_1_10_knowledge",
-      "translation": "On a scale of 1-10, how would you rate your current knowledge of WHEN to wash your hands?\n\n(1 = I don't know anything, 10 = I'm great and I teach others)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:13:34Z",
-      "updated_at": "2020-03-17T23:13:48Z",
-      "language": "en"
-    },
-    {
-      "id": 4082,
       "label": "drill_2_when_to_intro",
       "translation": "Il existe de nombreuses possibilités pour se laver les mains au travail. Dans cet exercice, nous allons apprendre quand vous devez vous laver les mains pour éviter la propagation des maladies.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:00:26Z",
-      "updated_at": "2020-03-25T01:01:22Z",
       "language": "fr"
     },
     {
-      "id": 4084,
       "label": "drill_2_when_to_intro",
       "translation": "Hay muchas oportunidades para lavarse las manos en el trabajo. En este ejercicio, se centrará en los momentos en que debe lavarse las manos para evitar la propagación de la enfermedad.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:00:49Z",
-      "updated_at": "2020-03-18T00:00:49Z",
       "language": "es"
     },
     {
-      "id": 4085,
       "label": "drill_when_to_practice_1",
       "translation": "Solo necesita lavarse las manos cuando estén visiblemente sucias.\n\na) verdad\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:01:22Z",
-      "updated_at": "2020-03-24T00:17:20Z",
       "language": "es"
     },
     {
-      "id": 4074,
       "label": "drill_when_to_fact_1",
       "translation": "FACT: You need to wash your hands to remove dirt AND germs. Germs are invisible. So, it's impossible to know where they are.  ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:31:13Z",
-      "updated_at": "2020-03-17T23:31:33Z",
       "language": "en"
     },
     {
-      "id": 4075,
       "label": "drill_when_to_practice_2",
       "translation": "Choose the best option to fill in the space.\n\nLatex gloves are [---] a replacement for handwashing. \n\na) always\nb) sometimes\nc) never",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:33:00Z",
-      "updated_at": "2020-03-23T00:25:21Z",
       "language": "en"
     },
     {
-      "id": 4076,
       "label": "drill_when_to_fact_2",
-      "translation": "FACT: Single-use (latex\/nitrile) gloves are great, but they are not a replacement for washing your hands. In fact, you should your hands before you put on gloves. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:35:59Z",
-      "updated_at": "2020-03-17T23:36:19Z",
+      "translation": "FACT: Single-use (latex/nitrile) gloves are great, but they are not a replacement for washing your hands. In fact, you should your hands before you put on gloves. ",
       "language": "en"
     },
     {
-      "id": 4097,
       "label": "drill_when_to_practice_3",
       "translation": "Lávese las manos después de que usted haya [---].\n\na) utilizado su teléfono\nb) tocado la basura \nc) utilizado el baño\nd) dado la mano a alguien\ne) todos los anteriores\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:06:21Z",
-      "updated_at": "2020-03-21T00:51:23Z",
       "language": "es"
     },
     {
-      "id": 4078,
       "label": "drill_when_to_fact_3",
       "translation": "FACT: It's also a good idea to wash your hands after you've been outside. You've probably touched dirty doors or handrails without realizing it. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:43:02Z",
-      "updated_at": "2020-03-17T23:43:33Z",
       "language": "en"
     },
     {
-      "id": 4073,
       "label": "drill_when_to_practice_1",
       "translation": "You only need to wash your hands when they are visibly dirty. \n\na) true\nb) false",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:25:35Z",
-      "updated_at": "2020-03-24T00:17:15Z",
       "language": "en"
     },
     {
-      "id": 4080,
       "label": "drill_when_to_fact_4",
       "translation": "FACT: We touch our phones a lot -- 2,000 times per day! The average smartphone has 15x more germs on its surface than a public bathroom. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:50:19Z",
-      "updated_at": "2020-03-17T23:50:40Z",
       "language": "en"
     },
     {
-      "id": 4071,
       "label": "drill_2_when_to_intro",
       "translation": "There are a lot of opportunities to wash your hands at work. In this drill, you will focus on the times when you should wash your hands to prevent the spread of disease.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:18:04Z",
-      "updated_at": "2020-03-23T00:09:18Z",
       "language": "en"
     },
     {
-      "id": 4089,
       "label": "drill_when_to_fact_1",
       "translation": "FATO: Você precisa lavar as mãos para remover a sujeira E os germes. Os germes são invisíveis. Então, é impossível saber onde eles estão.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:02:38Z",
-      "updated_at": "2020-03-18T00:02:38Z",
       "language": "pt"
     },
     {
-      "id": 4091,
       "label": "drill_when_to_fact_2",
-      "translation": "HECHO: Los guantes de un solo uso (látex \/ nitrilo) son excelentes pero no sustituyen el lavarse las manos. De hecho, debería lavarse las manos antes de ponerse los guantes. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:04:43Z",
-      "updated_at": "2020-03-23T00:39:25Z",
+      "translation": "HECHO: Los guantes de un solo uso (látex / nitrilo) son excelentes pero no sustituyen el lavarse las manos. De hecho, debería lavarse las manos antes de ponerse los guantes. \n",
       "language": "es"
     },
     {
-      "id": 4088,
       "label": "drill_when_to_fact_1",
       "translation": "LES FAITS: Il faut se laver pour enlever la saleté ET les germes. Les germes sont invisibles. C’est impossible de savoir où ils sont.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:02:28Z",
-      "updated_at": "2020-03-23T00:23:08Z",
       "language": "fr"
     },
     {
-      "id": 4081,
       "label": "drill_when_to_practice_5",
       "translation": "Gabby's about to eat. What should she plan to do?\n\na) wash her hands before \nb) wash her hands after\nc) wash her hands before and after\nd) wipe her hands on a towel\ne) nothing",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:51:30Z",
-      "updated_at": "2020-03-23T00:48:53Z",
       "language": "en"
     },
     {
-      "id": 4087,
       "label": "drill_when_to_practice_1",
       "translation": "Il faut seulement se laver les mains quand elles ont l’air sales. \n\na) Vrai\nb) Faux\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:02:04Z",
-      "updated_at": "2020-03-24T00:17:25Z",
       "language": "fr"
     },
     {
-      "id": 3848,
-      "label": "update_grey",
-      "translation": "Prochaine banque alimentaire le mercredi 4\/1. Textez Allan à tout moment 631-987-2545",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:27:50Z",
-      "updated_at": "2020-03-27T18:25:43Z",
-      "language": "fr"
-    },
-    {
-      "id": 4093,
       "label": "drill_when_to_fact_2",
-      "translation": "LES FAITS: Les gants à usage unique (latex\/nitrile) sont utiles mais ils ne remplacent pas le lavage des mains. Il faut se laver les mains avant de mettre des gants et après les avoir retirés. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:05:08Z",
-      "updated_at": "2020-03-23T00:39:50Z",
+      "translation": "LES FAITS: Les gants à usage unique (latex/nitrile) sont utiles mais ils ne remplacent pas le lavage des mains. Il faut se laver les mains avant de mettre des gants et après les avoir retirés. \n",
       "language": "fr"
     },
     {
-      "id": 4077,
       "label": "drill_when_to_practice_3",
       "translation": "Wash your hands after you [---].\n\na) use your phone\nb) touch garbage \nc) use the toilet\nd) shake someone's hand\ne) all of the above\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:41:09Z",
-      "updated_at": "2020-03-21T00:49:42Z",
       "language": "en"
     },
     {
-      "id": 4079,
       "label": "drill_when_to_practice_4",
       "translation": "He needs to wash his hands because [---].\n\na) he coughed into them\nb) he walked outside \nc) he is over 30 years old\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-17T23:44:07Z",
-      "updated_at": "2020-03-21T00:53:36Z",
       "language": "en"
     },
     {
-      "id": 4090,
       "label": "drill_when_to_fact_1",
       "translation": "HECHO: Tiene que lavarse las manos para eliminar el sucio Y los gérmenes. Los gérmenes son invisibles. Por lo tanto es imposible saber dónde están.  ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:02:54Z",
-      "updated_at": "2020-03-23T00:23:03Z",
       "language": "es"
     },
     {
-      "id": 4095,
       "label": "drill_when_to_practice_2",
       "translation": "Escolha a melhor opção para preencher o espaço em branco.\n\nAs luvas de látex são [---] um substituto para a lavagem das mãos.\n\na) sempre\nb) às vezes\nc) nunca",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:05:48Z",
-      "updated_at": "2020-03-23T00:42:18Z",
       "language": "pt"
     },
     {
-      "id": 4096,
       "label": "drill_when_to_practice_2",
       "translation": "Elija la mejor opción para llenar el blanco.\n\nLos guantes de látex son [---] una sustitución para el lavado de manos. \n\na) siempre\nb) a veces\nc) nunca\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:05:57Z",
-      "updated_at": "2020-03-23T00:42:02Z",
       "language": "es"
     },
     {
-      "id": 4083,
       "label": "drill_2_when_to_intro",
       "translation": "Existem muitas oportunidades para lavar as mãos no trabalho. Nesta seção, você se concentrará nos momentos em que deve lavar as mãos para evitar a propagação da doença.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:00:34Z",
-      "updated_at": "2020-03-25T01:01:28Z",
       "language": "pt"
     },
     {
-      "id": 4098,
       "label": "drill_when_to_practice_3",
       "translation": "Lave as mãos depois de fazer [---].\n\na) usou seu telefone\nb) tocou o lixo \nc) usou o banheiro\nd) apertou as mãos de alguém\ne) todos acima",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:06:32Z",
-      "updated_at": "2020-03-23T00:43:47Z",
       "language": "pt"
     },
     {
-      "id": 4107,
       "label": "drill_when_to_fact_4",
       "translation": "FATO: Tocamos muito em nossos telefones - 2.000 vezes por dia! O smartphone médio tem 15 vezes mais germes em sua superfície do que um banheiro público.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:09:22Z",
-      "updated_at": "2020-03-23T00:48:29Z",
       "language": "pt"
     },
     {
-      "id": 4111,
       "label": "drill_when_to_practice_5",
       "translation": "Gabby s’apprête à manger un repas. Que devrait-elle faire? \n\na) Se laver les mains avant\nb) Se laver les mains après\nc) Se laver les mains avant et après\nd) Se frotter les mains avec un torchon\ne) Rien\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:10:27Z",
-      "updated_at": "2020-03-23T00:49:28Z",
       "language": "fr"
     },
     {
-      "id": 4099,
       "label": "drill_when_to_practice_3",
       "translation": "Lavez-vous les mains après avoir [---]\n\na) utilisé votre téléphone\nb) touché des déchets\nc) été aux toilettes\nd) serré la main de quelqu’un\ne) toutes les réponses ci-dessus\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:06:47Z",
-      "updated_at": "2020-03-21T00:51:00Z",
       "language": "fr"
     },
     {
-      "id": 4103,
       "label": "drill_when_to_practice_4",
       "translation": "Él necesita lavarse las manos porque [---].\n\na) tosió en ellas\nb) fue para afuera \nc) tiene más de 30 años\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:08:32Z",
-      "updated_at": "2020-03-21T00:55:15Z",
       "language": "es"
     },
     {
-      "id": 4102,
       "label": "drill_when_to_fact_3",
       "translation": "HECHO: También es una buena idea lavarse las manos después de haber estado afuera. Es probable que haya tocado puertas o pasamanos sucios sin darse cuenta. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:07:30Z",
-      "updated_at": "2020-03-23T00:44:42Z",
       "language": "es"
     },
     {
-      "id": 4100,
       "label": "drill_when_to_fact_3",
       "translation": "LES FAITS: C’est une bonne idée de vous lavez les mains après être allé(e) dehors. Vous avez probablement touché des poignées de porte ou des rampes d’escalier sans vous en rendre compte. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:07:09Z",
-      "updated_at": "2020-03-23T00:44:50Z",
       "language": "fr"
     },
     {
-      "id": 4101,
       "label": "drill_when_to_fact_3",
       "translation": "FATO: Também é uma boa ideia lavar as mãos depois de sair. É provável que você tenha batido em portas ou trilhos sujos sem perceber.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:07:17Z",
-      "updated_at": "2020-03-23T00:45:19Z",
       "language": "pt"
     },
     {
-      "id": 4104,
       "label": "drill_when_to_practice_4",
       "translation": "Ele precisa lavar as mãos porque [---].\n\na) ele tossiu para eles\nb) ele saiu lá fora \nc) ele tem mais de 30 anos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:08:41Z",
-      "updated_at": "2020-03-23T00:47:11Z",
       "language": "pt"
     },
     {
-      "id": 4106,
       "label": "drill_when_to_fact_4",
       "translation": "LES FAITS: Nous touchons nos téléphones en permanence, presque 2000 fois par jour! En moyenne, nos portables ont 15 fois plus de germes sur leur surface que des toilettes publiques. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:09:13Z",
-      "updated_at": "2020-03-23T00:47:52Z",
       "language": "fr"
     },
     {
-      "id": 4109,
       "label": "drill_when_to_practice_5",
       "translation": "Gabby está a punto de comer. ¿Qué debería planificar hacer?\n\na) lavarse las manos primero \nb) lavarse las manos después \nc) lavarse las manos antes y después\nd) limpiarse sus manos con una toalla\ne) nada",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:09:59Z",
-      "updated_at": "2020-03-24T01:33:06Z",
       "language": "es"
     },
     {
-      "id": 4112,
-      "label": "bleach",
-      "translation": "bleach",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:36:09Z",
-      "updated_at": "2020-03-18T06:38:56Z",
-      "language": "en"
-    },
-    {
-      "id": 4113,
-      "label": "bleach",
-      "translation": "blanqueador \/ cloro",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:36:23Z",
-      "updated_at": "2020-03-18T06:39:01Z",
-      "language": "es"
-    },
-    {
-      "id": 4114,
-      "label": "bleach",
-      "translation": "javel",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:38:13Z",
-      "updated_at": "2020-03-18T06:39:06Z",
-      "language": "fr"
-    },
-    {
-      "id": 4115,
-      "label": "bleach",
-      "translation": "alvejante",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:38:48Z",
-      "updated_at": "2020-03-18T06:39:11Z",
-      "language": "pt"
-    },
-    {
-      "id": 4116,
-      "label": "sanitizer",
-      "translation": "sanitizer",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:40:38Z",
-      "updated_at": "2020-03-18T06:40:38Z",
-      "language": "en"
-    },
-    {
-      "id": 4117,
-      "label": "sanitizer",
-      "translation": "desinfectante",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:41:02Z",
-      "updated_at": "2020-03-18T06:41:02Z",
-      "language": "es"
-    },
-    {
-      "id": 4118,
-      "label": "sanitizer",
-      "translation": "désinfectant",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:41:31Z",
-      "updated_at": "2020-03-18T06:41:31Z",
-      "language": "fr"
-    },
-    {
-      "id": 4119,
-      "label": "sanitizer",
-      "translation": "desinfetante",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:42:08Z",
-      "updated_at": "2020-03-18T06:42:08Z",
-      "language": "pt"
-    },
-    {
-      "id": 4120,
-      "label": "label",
-      "translation": "label",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:43:35Z",
-      "updated_at": "2020-03-18T06:45:29Z",
-      "language": "en"
-    },
-    {
-      "id": 4121,
-      "label": "label",
-      "translation": "etiqueta",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:43:41Z",
-      "updated_at": "2020-03-18T06:45:34Z",
-      "language": "es"
-    },
-    {
-      "id": 4122,
-      "label": "label",
-      "translation": "étiquette",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:43:59Z",
-      "updated_at": "2020-03-18T06:45:39Z",
-      "language": "fr"
-    },
-    {
-      "id": 4123,
-      "label": "label",
-      "translation": "rótulo",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:45:23Z",
-      "updated_at": "2020-03-18T06:45:43Z",
-      "language": "pt"
-    },
-    {
-      "id": 4128,
-      "label": "sponge",
-      "translation": "esponja",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:47:31Z",
-      "updated_at": "2020-03-18T06:47:31Z",
-      "language": "pt"
-    },
-    {
-      "id": 4124,
-      "label": "sponge",
-      "translation": "sponge",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:46:39Z",
-      "updated_at": "2020-03-18T06:47:37Z",
-      "language": "en"
-    },
-    {
-      "id": 4125,
-      "label": "sponge",
-      "translation": "sponge",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:46:45Z",
-      "updated_at": "2020-03-18T06:47:41Z",
-      "language": "en"
-    },
-    {
-      "id": 4126,
-      "label": "sponge",
-      "translation": "esponja",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:46:49Z",
-      "updated_at": "2020-03-18T06:47:45Z",
-      "language": "es"
-    },
-    {
-      "id": 4127,
-      "label": "sponge",
-      "translation": "éponge",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:47:06Z",
-      "updated_at": "2020-03-18T06:47:49Z",
-      "language": "fr"
-    },
-    {
-      "id": 4129,
-      "label": "change",
-      "translation": "change",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:48:59Z",
-      "updated_at": "2020-03-18T06:48:59Z",
-      "language": "en"
-    },
-    {
-      "id": 4130,
-      "label": "change",
-      "translation": "change",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:49:07Z",
-      "updated_at": "2020-03-18T06:49:07Z",
-      "language": "en"
-    },
-    {
-      "id": 4131,
-      "label": "change",
-      "translation": "cambiar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:49:13Z",
-      "updated_at": "2020-03-18T06:49:13Z",
-      "language": "es"
-    },
-    {
-      "id": 4132,
-      "label": "change",
-      "translation": "changer",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:49:35Z",
-      "updated_at": "2020-03-18T06:49:35Z",
-      "language": "fr"
-    },
-    {
-      "id": 4133,
-      "label": "change",
-      "translation": "mudar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:50:27Z",
-      "updated_at": "2020-03-18T06:50:27Z",
-      "language": "pt"
-    },
-    {
-      "id": 4134,
-      "label": "cake",
-      "translation": "cake",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:54:29Z",
-      "updated_at": "2020-03-18T06:54:29Z",
-      "language": "en"
-    },
-    {
-      "id": 4135,
-      "label": "cake",
-      "translation": "cake",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:54:33Z",
-      "updated_at": "2020-03-18T06:54:33Z",
-      "language": "en"
-    },
-    {
-      "id": 4136,
-      "label": "cake",
-      "translation": "pastel \/ bizcocho \/ torta",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:54:40Z",
-      "updated_at": "2020-03-18T06:55:54Z",
-      "language": "es"
-    },
-    {
-      "id": 4137,
-      "label": "cake",
-      "translation": "gâteau",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:57:10Z",
-      "updated_at": "2020-03-18T06:57:10Z",
-      "language": "fr"
-    },
-    {
-      "id": 4138,
-      "label": "cake",
-      "translation": "bolo",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T06:57:31Z",
-      "updated_at": "2020-03-18T06:57:31Z",
-      "language": "pt"
-    },
-    {
-      "id": 4139,
-      "label": "preheat",
-      "translation": "preheat",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:58:40Z",
-      "updated_at": "2020-03-18T06:59:52Z",
-      "language": "en"
-    },
-    {
-      "id": 4140,
-      "label": "preheat",
-      "translation": "precalentar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:58:47Z",
-      "updated_at": "2020-03-18T06:59:56Z",
-      "language": "es"
-    },
-    {
-      "id": 4141,
-      "label": "preheat",
-      "translation": "préchauffer",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:59:19Z",
-      "updated_at": "2020-03-18T07:00:06Z",
-      "language": "fr"
-    },
-    {
-      "id": 4142,
-      "label": "preheat",
-      "translation": "pré-aquecer\n",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T06:59:46Z",
-      "updated_at": "2020-03-18T07:00:10Z",
-      "language": "pt"
-    },
-    {
-      "id": 4143,
-      "label": "batter",
-      "translation": "batter",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:02:12Z",
-      "updated_at": "2020-03-18T07:02:12Z",
-      "language": "en"
-    },
-    {
-      "id": 4144,
-      "label": "batter",
-      "translation": "masa",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:02:21Z",
-      "updated_at": "2020-03-18T07:02:21Z",
-      "language": "es"
-    },
-    {
-      "id": 4145,
-      "label": "batter",
-      "translation": "pâte",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:07:09Z",
-      "updated_at": "2020-03-18T07:07:09Z",
-      "language": "fr"
-    },
-    {
-      "id": 4146,
-      "label": "batter",
-      "translation": "massa",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:07:59Z",
-      "updated_at": "2020-03-18T07:07:59Z",
-      "language": "pt"
-    },
-    {
-      "id": 4147,
-      "label": "vanilla_extract",
-      "translation": "vanilla extract",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:08:44Z",
-      "updated_at": "2020-03-18T07:08:44Z",
-      "language": "en"
-    },
-    {
-      "id": 4148,
-      "label": "vanilla_extract",
-      "translation": "extracto de vainilla",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:08:49Z",
-      "updated_at": "2020-03-18T07:08:49Z",
-      "language": "es"
-    },
-    {
-      "id": 4149,
-      "label": "vanilla_extract",
-      "translation": "extrait de vanille",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:09:02Z",
-      "updated_at": "2020-03-18T07:09:02Z",
-      "language": "fr"
-    },
-    {
-      "id": 4150,
-      "label": "vanilla_extract",
-      "translation": "extrato de baunilha",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:09:17Z",
-      "updated_at": "2020-03-18T07:09:17Z",
-      "language": "pt"
-    },
-    {
-      "id": 4151,
-      "label": "flour",
-      "translation": "flour",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:10:13Z",
-      "updated_at": "2020-03-18T07:10:51Z",
-      "language": "en"
-    },
-    {
-      "id": 4152,
-      "label": "flour",
-      "translation": "harina",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:10:18Z",
-      "updated_at": "2020-03-18T07:10:59Z",
-      "language": "es"
-    },
-    {
-      "id": 4153,
-      "label": "flour",
-      "translation": "farine",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:10:31Z",
-      "updated_at": "2020-03-18T07:11:04Z",
-      "language": "fr"
-    },
-    {
-      "id": 4154,
-      "label": "flour",
-      "translation": "farinha",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:10:45Z",
-      "updated_at": "2020-03-18T07:11:08Z",
-      "language": "pt"
-    },
-    {
-      "id": 4155,
-      "label": "measure",
-      "translation": "measure",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:12:29Z",
-      "updated_at": "2020-03-18T07:13:15Z",
-      "language": "en"
-    },
-    {
-      "id": 4156,
-      "label": "measure",
-      "translation": "medir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:12:34Z",
-      "updated_at": "2020-03-18T07:13:19Z",
-      "language": "es"
-    },
-    {
-      "id": 4157,
-      "label": "measure",
-      "translation": "mesurer",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:12:52Z",
-      "updated_at": "2020-03-18T07:13:23Z",
-      "language": "fr"
-    },
-    {
-      "id": 4158,
-      "label": "measure",
-      "translation": "medir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:13:09Z",
-      "updated_at": "2020-03-18T07:13:28Z",
-      "language": "pt"
-    },
-    {
-      "id": 4171,
-      "label": "bake",
-      "translation": "assar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:22:24Z",
-      "updated_at": "2020-03-18T07:22:47Z",
-      "language": "pt"
-    },
-    {
-      "id": 4159,
-      "label": "beat",
-      "translation": "beat",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:14:51Z",
-      "updated_at": "2020-03-18T07:16:55Z",
-      "language": "en"
-    },
-    {
-      "id": 4160,
-      "label": "beat",
-      "translation": "batir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:14:55Z",
-      "updated_at": "2020-03-18T07:17:00Z",
-      "language": "es"
-    },
-    {
-      "id": 4161,
-      "label": "beat",
-      "translation": "battre",
-      "translation_type": "answer",
-      "created_at": "2020-03-18T07:16:35Z",
-      "updated_at": "2020-03-18T07:17:05Z",
-      "language": "fr"
-    },
-    {
-      "id": 4162,
-      "label": "beat",
-      "translation": "bater",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:16:50Z",
-      "updated_at": "2020-03-18T07:17:09Z",
-      "language": "pt"
-    },
-    {
-      "id": 4163,
-      "label": "add",
-      "translation": "add",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:18:03Z",
-      "updated_at": "2020-03-18T07:19:03Z",
-      "language": "en"
-    },
-    {
-      "id": 4164,
-      "label": "add",
-      "translation": "add",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:18:08Z",
-      "updated_at": "2020-03-18T07:19:10Z",
-      "language": "en"
-    },
-    {
-      "id": 4165,
-      "label": "add",
-      "translation": "añadir",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:18:13Z",
-      "updated_at": "2020-03-18T07:19:16Z",
-      "language": "es"
-    },
-    {
-      "id": 4166,
-      "label": "add",
-      "translation": "ajouter",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:18:36Z",
-      "updated_at": "2020-03-18T07:19:20Z",
-      "language": "fr"
-    },
-    {
-      "id": 4167,
-      "label": "add",
-      "translation": "adicionar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:18:56Z",
-      "updated_at": "2020-03-18T07:19:25Z",
-      "language": "pt"
-    },
-    {
-      "id": 4168,
-      "label": "bake",
-      "translation": "bake",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:20:11Z",
-      "updated_at": "2020-03-18T07:22:33Z",
-      "language": "en"
-    },
-    {
-      "id": 4169,
-      "label": "bake",
-      "translation": "hornear",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:20:17Z",
-      "updated_at": "2020-03-18T07:22:38Z",
-      "language": "es"
-    },
-    {
-      "id": 4170,
-      "label": "bake",
-      "translation": "cuire",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:21:38Z",
-      "updated_at": "2020-03-18T07:22:42Z",
-      "language": "fr"
-    },
-    {
-      "id": 4172,
-      "label": "break",
-      "translation": "break",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T07:23:45Z",
-      "updated_at": "2020-03-18T07:23:45Z",
-      "language": "en"
-    },
-    {
-      "id": 4173,
-      "label": "break_verb",
-      "translation": "break verb",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:24:06Z",
-      "updated_at": "2020-03-18T07:24:52Z",
-      "language": "en"
-    },
-    {
-      "id": 4174,
-      "label": "break_verb",
-      "translation": "break verb",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:24:13Z",
-      "updated_at": "2020-03-18T07:24:56Z",
-      "language": "en"
-    },
-    {
-      "id": 4175,
-      "label": "break_verb",
-      "translation": "romper",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:24:19Z",
-      "updated_at": "2020-03-18T07:25:00Z",
-      "language": "es"
-    },
-    {
-      "id": 4176,
-      "label": "break_verb",
-      "translation": "casser",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:24:34Z",
-      "updated_at": "2020-03-18T07:25:06Z",
-      "language": "fr"
-    },
-    {
-      "id": 4177,
-      "label": "break_verb",
-      "translation": "quebrar",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:24:45Z",
-      "updated_at": "2020-03-18T07:25:11Z",
-      "language": "pt"
-    },
-    {
-      "id": 4178,
-      "label": "teaspoon",
-      "translation": "teaspoon",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:27:43Z",
-      "updated_at": "2020-03-18T07:29:17Z",
-      "language": "en"
-    },
-    {
-      "id": 4179,
-      "label": "teaspoon",
-      "translation": "cuchara para té\n",
-      "translation_type": "answer",
-      "created_at": "2020-03-18T07:27:48Z",
-      "updated_at": "2020-03-18T07:29:21Z",
-      "language": "es"
-    },
-    {
-      "id": 4180,
-      "label": "teaspoon",
-      "translation": "petit cuillère",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:28:30Z",
-      "updated_at": "2020-03-18T07:29:25Z",
-      "language": "fr"
-    },
-    {
-      "id": 4181,
-      "label": "teaspoon",
-      "translation": "colher de chá",
-      "translation_type": "vocab",
-      "created_at": "2020-03-18T07:29:10Z",
-      "updated_at": "2020-03-18T07:29:29Z",
-      "language": "pt"
-    },
-    {
-      "id": 4182,
       "label": "ready_for_hotline",
       "translation": "We have an update from your employer {{company}}. Reply \"yes\" to receive it.",
-      "translation_type": "system",
-      "created_at": "2020-03-18T20:49:55Z",
-      "updated_at": "2020-03-18T20:49:55Z",
       "language": "en"
     },
     {
-      "id": 4183,
       "label": "ready_for_hotline",
       "translation": "Tenemos una actualización de su empleador {{company}}. Responda \"sí\" para recibirlo.",
-      "translation_type": "system",
-      "created_at": "2020-03-18T20:50:59Z",
-      "updated_at": "2020-03-18T20:50:59Z",
       "language": "es"
     },
     {
-      "id": 4185,
       "label": "ready_for_hotline",
       "translation": "Temos uma atualização do seu empregador {{company}}. Responda \"sim\" para recebê-lo.",
-      "translation_type": "system",
-      "created_at": "2020-03-18T20:52:24Z",
-      "updated_at": "2020-03-18T20:52:24Z",
       "language": "pt"
     },
     {
-      "id": 4110,
       "label": "drill_when_to_practice_5",
       "translation": "Gabby está prestes a comer. O que você deve fazer?\n\na) lave as mãos primeiro \nb) lave as mãos depois \nc) lave as mãos antes e depois\nd) limpe as mãos com uma toalha\ne) nada",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:10:10Z",
-      "updated_at": "2020-03-23T00:49:40Z",
       "language": "pt"
     },
     {
-      "id": 4617,
-      "label": "percentage_alcohol_based",
-      "translation": "60-90% de álcool com base em",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:39:55Z",
-      "updated_at": "2020-03-23T20:39:55Z",
-      "language": "pt"
-    },
-    {
-      "id": 4105,
       "label": "drill_when_to_practice_4",
       "translation": "Il doit se laver les mains car [---]\n\na) il a toussé dans ses mains\nb) il a été dehors\nc) il a plus de 30 ans\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:08:53Z",
-      "updated_at": "2020-03-23T00:46:46Z",
       "language": "fr"
     },
     {
-      "id": 4619,
-      "label": "percentage_alcohol_based",
-      "translation": "sean 60-90% a base de alcohol ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:40:09Z",
-      "updated_at": "2020-03-23T20:40:09Z",
-      "language": "es"
-    },
-    {
-      "id": 4624,
-      "label": "yes",
-      "translation": "sí",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:49:22Z",
-      "updated_at": "2020-03-23T20:49:22Z",
-      "language": "es"
-    },
-    {
-      "id": 4626,
-      "label": "off_and_unplugged",
-      "translation": "off and unplugged",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T21:53:19Z",
-      "updated_at": "2020-03-23T21:53:19Z",
-      "language": "en"
-    },
-    {
-      "id": 4184,
       "label": "ready_for_hotline",
       "translation": "Nous avons une mise à jour de votre employeur {{company}}. Répondez \"oui\" pour le recevoir.",
-      "translation_type": "system",
-      "created_at": "2020-03-18T20:51:37Z",
-      "updated_at": "2020-03-18T20:51:37Z",
       "language": "fr"
     },
     {
-      "id": 4190,
-      "label": "wfh_intake_done",
-      "translation": "Finished! 🙌 🎉 😎\n\nYou will get your first lesson soon.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:11:48Z",
-      "updated_at": "2020-03-19T18:12:09Z",
-      "language": "en"
-    },
-    {
-      "id": 4191,
-      "label": "wfh_intake_done",
-      "translation": "¡Terminado! 🙌 🎉 😎\n\nRecibirá su primera lección pronto.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:13:01Z",
-      "updated_at": "2020-03-19T18:13:01Z",
-      "language": "es"
-    },
-    {
-      "id": 4192,
-      "label": "wfh_intake_done",
-      "translation": "Fini! 🙌 🎉 😎\n\nVous aurez bientôt votre première leçon.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:13:15Z",
-      "updated_at": "2020-03-19T18:13:15Z",
-      "language": "fr"
-    },
-    {
-      "id": 4193,
-      "label": "wfh_intake_done",
-      "translation": "Acabado! 🙌 🎉 😎\n\nVocê receberá sua primeira lição em breve.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:13:33Z",
-      "updated_at": "2020-03-19T18:13:33Z",
-      "language": "pt"
-    },
-    {
-      "id": 4194,
-      "label": "wfh_intake_time",
-      "translation": "What time do you prefer to receive lessons? ⌚️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:13:56Z",
-      "updated_at": "2020-03-19T18:14:31Z",
-      "language": "en"
-    },
-    {
-      "id": 4195,
-      "label": "wfh_intake_time",
-      "translation": "A que horas você prefere receber aulas? ⌚️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:14:42Z",
-      "updated_at": "2020-03-19T18:14:42Z",
-      "language": "pt"
-    },
-    {
-      "id": 4196,
-      "label": "wfh_intake_time",
-      "translation": "À quelle heure préférez-vous recevoir des leçons? ⌚️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:14:53Z",
-      "updated_at": "2020-03-19T18:14:53Z",
-      "language": "fr"
-    },
-    {
-      "id": 4197,
-      "label": "wfh_intake_time",
-      "translation": "¿A qué hora prefieres recibir las clases? ⌚️",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:15:06Z",
-      "updated_at": "2020-03-19T18:15:06Z",
-      "language": "es"
-    },
-    {
-      "id": 4198,
-      "label": "intake_free_off_work",
-      "translation": "{{company}} oferece aulas de inglês online gratuitas enquanto você está fora do trabalho.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:15:44Z",
-      "updated_at": "2020-03-19T18:15:44Z",
-      "language": "pt"
-    },
-    {
-      "id": 4187,
-      "label": "intake_free_off_work",
-      "translation": "{{company}} proporciona clases de inglés en línea gratuitas mientras estás fuera del trabajo.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T06:03:21Z",
-      "updated_at": "2020-03-19T18:21:39Z",
-      "language": "es"
-    },
-    {
-      "id": 4199,
-      "label": "intake_free_off_work",
-      "translation": "{{company}} propose des cours d'anglais gratuits pendant que vous êtes absent du travail.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T18:22:23Z",
-      "updated_at": "2020-03-19T18:22:23Z",
-      "language": "fr"
-    },
-    {
-      "id": 4186,
-      "label": "intake_free_off_work",
-      "translation": "{{company}} is providing free online English lessons while you're off from work.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-19T06:02:33Z",
-      "updated_at": "2020-03-19T18:36:37Z",
-      "language": "en"
-    },
-    {
-      "id": 3838,
-      "label": "update_acr",
-      "translation": "Bonjour l'équipe,\nNous savons que les temps sont particulièrement difficiles en ce moment. Nous avons rassemblé de la nourriture que nous mettons gratuitement à la disposition du personnel aujourd'hui, jeudi 3\/19, selon le principe du premier arrivé, premier servi. Visitez Aux Kitchen à tout moment entre 13 h et 15 h pour ramasser de la nourriture (1519, promenade Brookside).\nVeuillez apporter un sac \/ boîte de la maison pour transporter de la nourriture car nous en avons très peu. De plus, si vous voulez des œufs, apportez une boîte vide et nous la remplirons pour vous.\nNous espérons vous voir demain!\nTeam ACR",
-      "translation_type": "lesson",
-      "created_at": "2020-03-15T00:26:47Z",
-      "updated_at": "2020-03-19T18:36:50Z",
-      "language": "fr"
-    },
-    {
-      "id": 4062,
-      "label": "update_acr",
-      "translation": "Olá equipe,\nSabemos que os tempos são particularmente difíceis no momento. Reunimos alguns alimentos que estamos disponibilizando para que os funcionários possam pegar de graça hoje, quinta-feira, 19\/03, por ordem de chegada. Visite Aux Kitchen a qualquer momento entre 13:00 e 15:00 para pegar comida (1519 Brookside Drive).\nPor favor, traga uma sacola \/ caixa de casa para levar comida, pois temos muito poucas. Além disso, se você quiser ovos, traga uma caixa vazia e nós a preencheremos para você.\nEsperamos vê-lo amanhã!\nTeam ACR",
-      "translation_type": "lesson",
-      "created_at": "2020-03-16T20:42:39Z",
-      "updated_at": "2020-03-19T18:37:01Z",
-      "language": "pt"
-    },
-    {
-      "id": 3774,
-      "label": "update_acr",
-      "translation": "Hi Team,\nWe know that times are particularly difficult right now. We have gathered some food that we are making available for staff to pick up for free tomorrow, Thursday 3\/19, on a first come first served basis. Please come by Aux Kitchen any time between 1:00 - 3:00 pm to pick up food (1519 Brookside Drive).\nPlease bring a bag\/box from home to take the food with you, as we are very low on to go supplies. Also, if you'd like eggs, please bring an empty carton with you and we'll fill it up for you.\nWe hope to see you tomorrow!\nTeam ACR",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:41:35Z",
-      "updated_at": "2020-03-19T18:37:17Z",
-      "language": "en"
-    },
-    {
-      "id": 4212,
       "label": "text_go",
       "translation": "Text me the word GO when you're ready to start.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:33:04Z",
-      "updated_at": "2020-03-20T19:33:29Z",
       "language": "en"
     },
     {
-      "id": 4213,
       "label": "text_go",
       "translation": "Enviame un texto con la palabra GO cuando estés listo para comenzar.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:34:45Z",
-      "updated_at": "2020-03-20T19:34:45Z",
       "language": "es"
     },
     {
-      "id": 4214,
       "label": "text_go",
       "translation": "Répondez à ce message en tapant GO quand vous êtes prêts à commencer. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:35:20Z",
-      "updated_at": "2020-03-20T19:35:20Z",
       "language": "fr"
     },
     {
-      "id": 4215,
       "label": "text_go",
       "translation": "如果你准备好了，请回复“GO”。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:36:06Z",
-      "updated_at": "2020-03-20T19:36:06Z",
       "language": "zh"
     },
     {
-      "id": 4216,
       "label": "drill_intro_2",
       "translation": "今天的主题是",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:37:35Z",
-      "updated_at": "2020-03-20T19:37:35Z",
       "language": "zh"
     },
     {
-      "id": 4217,
       "label": "drill_self_assess_2",
       "translation": "给自己关于今天主题的了解打个分吧？",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:38:26Z",
-      "updated_at": "2020-03-20T19:38:26Z",
       "language": "zh"
     },
     {
-      "id": 4218,
       "label": "drill_self_assess_1",
       "translation": "好！让我们开始吧。首先让我们对你有多一点了解吧。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:38:40Z",
-      "updated_at": "2020-03-20T19:38:40Z",
       "language": "zh"
     },
     {
-      "id": 4220,
       "label": "thank_you",
       "translation": "谢谢你！",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:40:03Z",
-      "updated_at": "2020-03-20T19:40:03Z",
       "language": "zh"
     },
     {
-      "id": 4219,
       "label": "likert_1_10_knowledge",
       "translation": "（1分代表完全不了解，10分代表非常了解，并且可以教给身边的其他人）\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:39:14Z",
-      "updated_at": "2020-03-20T19:39:14Z",
       "language": "zh"
     },
     {
-      "id": 4246,
       "label": "covid_1_practice_4",
       "translation": "Answer the question.\n\nWhat are the most common symptoms of COVID-19?\n\na) Stomachache, nausea, diarrhea\nb) Fever, cough, shortness of breath\nc) Itchy rash\nd) Blurred vision\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:58:08Z",
-      "updated_at": "2020-03-23T01:59:51Z",
       "language": "en"
     },
     {
-      "id": 4225,
-      "label": "coivd_1_fact_1",
-      "translation": "coivd 1 fact 1",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:42:49Z",
-      "updated_at": "2020-03-20T19:42:49Z",
-      "language": "en"
-    },
-    {
-      "id": 4228,
       "label": "covid_1_fact_1",
       "translation": "HECHO: COVID-19 no es una bacteria. Es una enfermedad viral. Si escuchas a alguien decir \"coronavirus\" o \"coronavirus novel\", están hablando de la misma enfermedad.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:44:11Z",
-      "updated_at": "2020-03-20T19:44:11Z",
       "language": "es"
     },
     {
-      "id": 4227,
       "label": "covid_1_fact_1",
       "translation": "LES FAITS: Le COVID-19 n’est pas une bactérie, c’est une maladie virale. Si vous entendez quelqu’un parler du “coronavirus” ou du “nouveau coronavirus”, ils parlent de la même chose. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:43:54Z",
-      "updated_at": "2020-03-20T19:44:39Z",
       "language": "fr"
     },
     {
-      "id": 4229,
       "label": "covid_1_fact_1",
       "translation": "2019 新型冠状病毒(COVID-19) 是病毒而不是细菌。除了 COVID-19，大家也会称之为 coronavirus 或者 novel coronavirus。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:44:59Z",
-      "updated_at": "2020-03-20T19:44:59Z",
       "language": "zh"
     },
     {
-      "id": 4233,
       "label": "covid_1_practice_2",
       "translation": "Elija la mejor opción para llenar el blanco. \n\nCOVID-19 es [---] la gripe. \n\na) tan contagioso como\nb) menos contagioso que\nc) más contagioso que\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:46:55Z",
-      "updated_at": "2020-03-23T01:49:08Z",
       "language": "es"
     },
     {
-      "id": 4230,
       "label": "covid_1_practice_2",
       "translation": "Fill in the blank by choosing the best answer.\n\nCOVID-19 is [---] the flu. \n\na) as contagious as\nb) less contagious than\nc) more contagious than\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:45:20Z",
-      "updated_at": "2020-03-23T01:49:12Z",
       "language": "en"
     },
     {
-      "id": 4239,
       "label": "covid_1_practice_3",
       "translation": "2019 新型冠状病毒(COVID-19)通过什么的途径在人和人之间传播？\nA）通过感染者与他人近距离（2米以内）接触\nB）通过感染者的咳嗽和喷嚏飞沫传播\nC）通过接触病毒污染的物体表面，然后触碰脸部传播\nD）以上全部方式\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:53:16Z",
-      "updated_at": "2020-03-23T01:55:20Z",
       "language": "zh"
     },
     {
-      "id": 4244,
       "label": "covid_1_fact_3",
       "translation": "LES FAITS: Une personne qui ne montre aucun symptôme du virus peut quand même être porteuse et contaminer d’autres personnes. Tenez-vous à distance des autres et gardez une bonne hygiène à tout moment. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:57:23Z",
-      "updated_at": "2020-03-22T20:37:56Z",
       "language": "fr"
     },
     {
-      "id": 4235,
       "label": "covid_1_fact_2",
       "translation": "HECHO: COVID-19 es más contagioso y más mortal que la gripe. Es importante que todos trabajemos juntos para controlar su propagación y salvar vidas.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:52:00Z",
-      "updated_at": "2020-03-20T19:52:00Z",
       "language": "es"
     },
     {
-      "id": 4236,
       "label": "covid_1_fact_2",
       "translation": "LES FAITS: Le COVID-19 est plus contagieux et plus mortel que la grippe. Il est très important que nous travaillions tous ensemble pour limiter sa propagation et sauver des vies. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:52:10Z",
-      "updated_at": "2020-03-20T19:52:10Z",
       "language": "fr"
     },
     {
-      "id": 4237,
       "label": "covid_1_fact_2",
       "translation": "2019 新型冠状病毒(COVID-19)的传染性和伤害性都比流感强很多。每个人都出一分力，才能控制病毒传播，拯救更多生命。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:52:23Z",
-      "updated_at": "2020-03-20T19:52:23Z",
       "language": "zh"
     },
     {
-      "id": 4234,
       "label": "covid_1_fact_2",
       "translation": "FACT: COVID-19 is more contagious and deadly than the flu. It is important that we all work together to control its spread and save lives.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:51:30Z",
-      "updated_at": "2020-03-22T00:00:12Z",
       "language": "en"
     },
     {
-      "id": 4243,
       "label": "covid_1_fact_3",
       "translation": "HECHO: Es posible que COVID-19 sea transmitido por personas que no muestran síntomas. Mantenga distancia de otras personas + practique buena higiene en todos momentos para estar seguro.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:57:00Z",
-      "updated_at": "2020-03-22T20:37:02Z",
       "language": "es"
     },
     {
-      "id": 4242,
       "label": "covid_1_fact_3",
       "translation": "FACT: It's possible for COVID-19 to be spread by people who don’t show symptoms. Keep your distance with other people + practice good hygiene all the time.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:56:19Z",
-      "updated_at": "2020-03-22T20:36:51Z",
       "language": "en"
     },
     {
-      "id": 4249,
       "label": "covid_1_practice_4",
       "translation": "Responda a la pregunta.\n\n¿Cuáles son los síntomas más comunes del COVID-19?\n\na) Dolor de estómago, náuseas, diarrea\nb) Fiebre, tos, dificultad al respirar\nc) Salpullido con comezón\nd) Visión borrosa\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:00:08Z",
-      "updated_at": "2020-03-23T01:59:58Z",
       "language": "es"
     },
     {
-      "id": 4245,
       "label": "covid_1_fact_3",
       "translation": "即使感染者不出现任何症状，新型冠状病毒(COVID-19) 仍可以由他们传染其他人。保险起见，请时刻尽量与其他人保持 2 米以上距离，并且注意个人卫生。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:57:51Z",
-      "updated_at": "2020-03-20T19:57:51Z",
       "language": "zh"
     },
     {
-      "id": 4226,
       "label": "covid_1_fact_1",
       "translation": "FACT:  COVID-19 is not a bacteria. It is a virus disease. If you hear someone say “coronavirus” or “novel coronavirus,” they are talking about the same thing.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:43:28Z",
-      "updated_at": "2020-03-23T23:44:59Z",
       "language": "en"
     },
     {
-      "id": 4223,
       "label": "covid_1_practice_1",
       "translation": "Vrai ou faux? \n\nLe COVID-19 est une bactérie\n\na) Vrai \nb) Faux",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:42:01Z",
-      "updated_at": "2020-03-23T01:46:54Z",
       "language": "fr"
     },
     {
-      "id": 4241,
       "label": "covid_1_practice_3",
       "translation": "Contesta la pregunta. \n\n¿Cómo se transmite COVID-19?\n\na) Contacto cercano con una persona infectada \nb) Gotas respiratorias en el aire cuando una persona enferma tose o estornuda\nc) Al tocar una superficie con el virus y luego tocarse la cara\nd) Todas las anteriores\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:55:11Z",
-      "updated_at": "2020-03-23T01:54:53Z",
       "language": "es"
     },
     {
-      "id": 4251,
       "label": "covid_1_fact_4",
       "translation": "HECHO: Si usted o alguien cerca de usted tiene dificultad al respirar, dolor de pecho, confusión o labios azules, busque atención médica inmediatamente.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:01:09Z",
-      "updated_at": "2020-03-20T20:01:09Z",
       "language": "es"
     },
     {
-      "id": 4250,
       "label": "covid_1_fact_4",
       "translation": "FACT: If you or someone near you has difficulty breathing, chest pain, confusion, or blue lips, get medical attention immediately.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:00:39Z",
-      "updated_at": "2020-03-22T00:11:21Z",
       "language": "en"
     },
     {
-      "id": 4222,
       "label": "covid_1_practice_1",
       "translation": "新冠肺炎是由细菌引起的。\n\na）正确\nb）错误\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:41:39Z",
-      "updated_at": "2020-03-23T01:47:02Z",
       "language": "zh"
     },
     {
-      "id": 4232,
       "label": "covid_1_practice_2",
       "translation": "Choisissez la meilleure option pour compléter la phrase. \n\nLe COVID-19 est [---] que la grippe. \n\na) aussi contagieux\nb) moins contagieux\nc) plus contagieux\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:46:27Z",
-      "updated_at": "2020-03-23T01:49:03Z",
       "language": "fr"
     },
     {
-      "id": 4231,
       "label": "covid_1_practice_2",
       "translation": "2019 新型冠状病毒(COVID-19)的传染性有多强？\n\nA）和流感一样\nB）比流感弱\nC）比流感强\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:45:42Z",
-      "updated_at": "2020-03-23T01:48:49Z",
       "language": "zh"
     },
     {
-      "id": 4248,
       "label": "covid_1_practice_4",
       "translation": "Répondez à cette question. \n\nQuels sont les symptômes les plus fréquents du COVID-19? \n\na) Maux de ventre, nausée, diarrhée\nb) Fièvre, toux, souffle court\nc) Démangeaison, éruption cutanée\nd) Vision floue\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:58:58Z",
-      "updated_at": "2020-03-23T01:59:43Z",
       "language": "fr"
     },
     {
-      "id": 4247,
       "label": "covid_1_practice_4",
       "translation": "2019 新型冠状病毒(COVID-19)最常见的症状是什么？\n\nA）腹痛、恶心、腹泻\nB）干咳、发烧、胸闷气短\nC）皮疹、瘙痒\nD）视力减退\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:58:48Z",
-      "updated_at": "2020-03-23T02:01:03Z",
       "language": "zh"
     },
     {
-      "id": 4252,
       "label": "covid_1_fact_4",
       "translation": "LES FAITS: Si vous ou quelqu’un autour de vous avez du mal à respirer, des douleurs à la poitrine, de la confusion, ou les lèvres bleues, demandez immédiatement une assistance médicale. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:01:23Z",
-      "updated_at": "2020-03-20T20:01:23Z",
       "language": "fr"
     },
     {
-      "id": 4253,
       "label": "covid_1_fact_4",
       "translation": "如果你或者周围有人出现呼吸困难、胸部疼痛、意识模糊或者嘴唇发青等症状，请即使就医。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:01:40Z",
-      "updated_at": "2020-03-20T20:01:40Z",
       "language": "zh"
     },
     {
-      "id": 4260,
       "label": "covid_1_fact_5",
       "translation": "HECHO: Si experimenta síntomas leves, autoaislamiento es lo mejor para controlar la propagación de COVID-19.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:12:23Z",
-      "updated_at": "2020-03-22T20:47:33Z",
       "language": "es"
     },
     {
-      "id": 4255,
       "label": "covid_1_practice_5",
       "translation": "如果你认为你自己出现了 2019 新型冠状病毒(COVID-19)的症状，你应该怎样做？\nA）除了出门就医之外，居家隔离\nB）避免乘坐公共交通工具\nC）在就诊前，先给医生或医院打电话咨询\nD）以上所有\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:03:20Z",
-      "updated_at": "2020-03-23T02:07:24Z",
       "language": "zh"
     },
     {
-      "id": 4254,
       "label": "covid_1_practice_5",
       "translation": "If you think you may have symptoms of COVID-19, you should [---]. \n\na) stay home, except to get medical care\nb) don't take public transportation\nc) call your doctor before you visit \nd) all of the above\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:02:24Z",
-      "updated_at": "2020-03-23T23:54:31Z",
       "language": "en"
     },
     {
-      "id": 4257,
       "label": "covid_1_practice_5",
       "translation": "Si cree que puede tener síntomas de COVID-19, debería [---]. \n\na) quedarse en casa, excepto para obtener atención médica\nb) no tomar transportación pública\nc) llamar a su médico antes de visitar \nd) Todas las anteriores",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:05:36Z",
-      "updated_at": "2020-03-24T02:16:04Z",
       "language": "es"
     },
     {
-      "id": 4256,
       "label": "covid_1_practice_5",
       "translation": "Si vous pensez que vous avez les symptômes du COVID-19, vous devez [---]\n\na) Rester à la maison, sauf pour recevoir des soins médicaux\nb) Ne pas prendre les transports publics \nc) Appeler votre médecin avant de lui rendre visite\nd) Toutes les options ci-dessus \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:04:10Z",
-      "updated_at": "2020-03-24T02:16:10Z",
       "language": "fr"
     },
     {
-      "id": 4258,
       "label": "drill_complete_congrats",
       "translation": "恭喜你，{{name}}！今天的培训到此结束，{{company}}会接到你已经完成的通知。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:07:14Z",
-      "updated_at": "2020-03-20T20:07:14Z",
       "language": "zh"
     },
     {
-      "id": 4289,
       "label": "drill_when_to_fact_4",
       "translation": "我们每天大约会触摸2000次手机。一个普通只能手机上的细菌甚至有厕所的15倍之多。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:56:40Z",
-      "updated_at": "2020-03-24T07:10:56Z",
       "language": "zh"
     },
     {
-      "id": 4281,
-      "label": "drill_requirements_3_start",
-      "translation": "如果你准备好了，请回复“准备”。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:35:29Z",
-      "updated_at": "2020-03-21T00:35:59Z",
-      "language": "zh"
-    },
-    {
-      "id": 4259,
       "label": "covid_1_fact_5",
       "translation": "FACT: If you are experiencing only mild symptoms, self isolate to control the spread of COVID-19.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:11:53Z",
-      "updated_at": "2020-03-22T20:46:48Z",
       "language": "en"
     },
     {
-      "id": 4262,
       "label": "stop_covid_thanks",
       "translation": "Nous vous remercions de prendre le temps de faire cette formation StopCovid. En faisant ces courts exercices tous les jours, vous aidez à ralentir la progression du Coronavirus. \n\nNous éliminerons le COVID-19 tous ensemble. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:49:28Z",
-      "updated_at": "2020-03-22T20:01:39Z",
       "language": "fr"
     },
     {
-      "id": 4263,
       "label": "stop_covid_thanks",
       "translation": "感谢你参加我们的安全培训。采取这些预防措施，你就能实实在在地帮助阻止病毒传播。让我们一起战胜这次新型冠状病毒(COVID-19) 疫情。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:49:42Z",
-      "updated_at": "2020-03-21T19:09:32Z",
       "language": "zh"
     },
     {
-      "id": 4282,
       "label": "drill_when_to_practice_1",
       "translation": "只有能看到手脏了的时候，你才需要洗手。\n\na）正确\nb）错误\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:39:54Z",
-      "updated_at": "2020-03-24T00:17:34Z",
       "language": "zh"
     },
     {
-      "id": 4291,
       "label": "covid_prev_practice_1",
       "translation": "Answer the question.\n\nWhat is the best way to prevent becoming ill from COVID-19?\n\na) Get the vaccine from your doctor\nb) Avoid being exposed to the virus\nc) Drink lots of water\nd) Eat leafy greens",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:11:57Z",
-      "updated_at": "2020-03-22T21:07:37Z",
       "language": "en"
     },
     {
-      "id": 4265,
       "label": "ok_thanks",
       "translation": "🤖 谢谢你！👍",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "zh"
     },
     {
-      "id": 4267,
       "label": "corrected_answer",
       "translation": "🤖正确答案:  *{{correct_answer}}*.\n\n下一题。",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "zh"
     },
     {
-      "id": 4268,
-      "label": "hand_washing_how_to",
-      "translation": "如何洗手",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T23:46:14Z",
-      "updated_at": "2020-03-20T23:46:14Z",
-      "language": "zh"
-    },
-    {
-      "id": 4269,
-      "label": "drill_intro_3",
-      "translation": "如果你准备好了，请回复“好”。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T23:48:44Z",
-      "updated_at": "2020-03-20T23:49:39Z",
-      "language": "zh"
-    },
-    {
-      "id": 4270,
       "label": "drill_self_assess_3",
       "translation": "（放心！我们会为你的答案保密）",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T23:53:29Z",
-      "updated_at": "2020-03-20T23:53:29Z",
       "language": "zh"
     },
     {
-      "id": 4221,
       "label": "covid_1_practice_1",
       "translation": "True or false?\n\nCOVID-19 is a bacteria.\n\na) true\nb) false",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:40:15Z",
-      "updated_at": "2020-03-23T01:46:40Z",
       "language": "en"
     },
     {
-      "id": 4272,
       "label": "answer_the_question",
       "translation": "回答问题",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:12:54Z",
-      "updated_at": "2020-03-21T00:12:54Z",
       "language": "zh"
     },
     {
-      "id": 4273,
       "label": "drill_how_to_fact_2",
       "translation": "去除细菌时，热水和冷水都一样有效．重要的是您使用的肥皂量以及洗手时间．",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:13:30Z",
-      "updated_at": "2020-03-21T00:13:30Z",
       "language": "zh"
     },
     {
-      "id": 3252,
       "label": "drill_how_to_fact_2",
       "translation": "LES FAITS: L’eau chaude est efficace pour enlever la graisse ou l’huile des mains. Dans le cas des germes, l’eau chaude ou l’eau froide ont la même efficacité. Un bon lavage de mains dépend de la quantité de savon que vous utilisez and combien de temps vous vous frottez les mains. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:27:02Z",
-      "updated_at": "2020-03-21T00:13:44Z",
       "language": "fr"
     },
     {
-      "id": 4274,
       "label": "drill_practice_caps",
       "translation": "PRACTICE",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:16:02Z",
-      "updated_at": "2020-03-21T00:16:16Z",
       "language": "en"
     },
     {
-      "id": 4275,
       "label": "drill_practice_caps",
       "translation": "EJERCICIO",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:16:24Z",
-      "updated_at": "2020-03-21T00:16:24Z",
       "language": "es"
     },
     {
-      "id": 4276,
       "label": "drill_practice_caps",
       "translation": "EXERCICE",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:16:36Z",
-      "updated_at": "2020-03-21T00:16:36Z",
       "language": "fr"
     },
     {
-      "id": 4277,
       "label": "drill_practice_caps",
       "translation": "问题",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:16:49Z",
-      "updated_at": "2020-03-21T00:16:49Z",
       "language": "zh"
     },
     {
-      "id": 4278,
       "label": "drill_how_to_practice_2",
       "translation": "如果你的洗手液是按压式的，洗手时应该用多少肥皂?\n\na）按一次\nb）按两三次\nc）不用洗手液\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:18:57Z",
-      "updated_at": "2020-03-21T00:18:57Z",
       "language": "zh"
     },
     {
-      "id": 4280,
-      "label": "when_to_wash_your_hands",
-      "translation": "什么时候需要洗手",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:33:35Z",
-      "updated_at": "2020-03-21T00:33:35Z",
-      "language": "zh"
-    },
-    {
-      "id": 4284,
       "label": "drill_when_to_practice_2",
       "translation": "在什么情况下，戴橡胶手套可以代替洗手？\n\na）任何情况都可以代替洗手\nb）在特殊情况下才需要洗手\nc）即便在戴手套的情况下，也需要洗手\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:47:43Z",
-      "updated_at": "2020-03-21T00:47:43Z",
       "language": "zh"
     },
     {
-      "id": 4286,
       "label": "drill_when_to_practice_3",
       "translation": "在做了以下哪些事情时候，需要洗手\n\nA）使用手机\nB）处理垃圾\nC）去洗手间\nD）和别人握手\nE）以上全部选项\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:50:11Z",
-      "updated_at": "2020-03-21T00:50:11Z",
       "language": "zh"
     },
     {
-      "id": 4288,
       "label": "drill_when_to_practice_4",
       "translation": "图中的人为什么需要洗手？\n\nA）他用手遮盖了他的咳嗽\nB）他出门了\nC）他已经三十多岁了\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:56:02Z",
-      "updated_at": "2020-03-21T00:56:02Z",
       "language": "zh"
     },
     {
-      "id": 4285,
       "label": "drill_when_to_fact_2",
       "translation": "一次性收到虽然有很大的作用，但它并不能代替洗手的作用。我们应该在戴手套前洗一次手。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:48:07Z",
-      "updated_at": "2020-03-23T00:41:40Z",
       "language": "zh"
     },
     {
-      "id": 4292,
       "label": "covid_prev_practice_1",
       "translation": "Contesta la pregunta\n\n¿Cuál es la mejor manera de evitar enfermarse con COVID-19?\n\na) Obtenga la vacuna de su médico\nb) Evite exponerse al virus\nc) Beba mucha agua\nd) Coma verduras de hoja \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:12:44Z",
-      "updated_at": "2020-03-21T01:12:44Z",
       "language": "es"
     },
     {
-      "id": 4294,
       "label": "covid_prev_practice_1",
       "translation": "预防 2019 新型冠状病毒(COVID-19)的最佳方式是什么？\nA）接种疫苗\nB）尽量避免和病毒的接触\nC）多喝水\nD）多吃蔬菜\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:14:51Z",
-      "updated_at": "2020-03-21T01:14:51Z",
       "language": "zh"
     },
     {
-      "id": 4264,
       "label": "stop_covid_thanks",
       "translation": "Gracias por tomar de su tiempo para entrenamiento StopCovid. Al completar estas actividades diariamente, usted estará ayudando a prevenir la transmisión de Coronavirus. \n\nJuntos podemos detener el COVID-19.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:49:58Z",
-      "updated_at": "2020-03-21T19:09:40Z",
       "language": "es"
     },
     {
-      "id": 4287,
       "label": "drill_when_to_fact_3",
       "translation": "出门之后也应该洗个手。在外面，你很可能不经意间接触了没那么干净的门把手或扶手。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:52:58Z",
-      "updated_at": "2020-03-23T00:45:26Z",
       "language": "zh"
     },
     {
-      "id": 4271,
       "label": "drill_how_to_practice_1",
       "translation": "洗手只能用温水。\n\na）正确\nb）错误",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:11:18Z",
-      "updated_at": "2020-03-23T01:44:24Z",
       "language": "zh"
     },
     {
-      "id": 4279,
       "label": "drill_how_to_fact_3",
       "translation": "按两次以上！\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:28:50Z",
-      "updated_at": "2020-03-24T07:07:51Z",
       "language": "zh"
     },
     {
-      "id": 4283,
       "label": "drill_when_to_fact_1",
       "translation": "洗手的目的是去除手上的能看到的污垢，和看不见的细菌和病毒，所以即使手上看起来不脏，你也需要洗手。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:43:43Z",
-      "updated_at": "2020-03-24T07:10:37Z",
       "language": "zh"
     },
     {
-      "id": 4290,
       "label": "drill_when_to_practice_5",
       "translation": "小张要吃饭了，她需要做些什么\n\nA）饭前洗手\nB）饭后洗手\nC）饭前饭后都要洗手\nD）用毛巾把手擦干\nE）什么都不做",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T00:58:32Z",
-      "updated_at": "2020-03-24T07:11:08Z",
       "language": "zh"
     },
     {
-      "id": 3463,
       "label": "incorrect_answer",
       "translation": "🤖 这不是正确答案，你可以再试一次！",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "zh"
     },
     {
-      "id": 3797,
-      "label": "update_grey",
-      "translation": "Next food bank on Wednesday 4\/1. Text Allan anytime 631-987-2545",
-      "translation_type": "lesson",
-      "created_at": "2020-03-14T23:43:51Z",
-      "updated_at": "2020-03-27T18:25:25Z",
-      "language": "en"
-    },
-    {
-      "id": 4266,
       "label": "incorrect_answer",
       "translation": "🤖 Desculpe, não está correto. 🤔\n\n* Tente mais uma vez! *",
-      "translation_type": "system",
-      "created_at": "2020-02-22T19:00:00Z",
-      "updated_at": "2020-02-22T19:00:00Z",
       "language": "pt"
     },
     {
-      "id": 4300,
       "label": "covid_prev_practice_2",
       "translation": "¿Cuál es la mejor manera de evitar la exposición al COVID-19?\n\na) Mantener una distancia social\nb) Lavarse las manos con frecuencia\nc) Evitar tocarse los ojos, la nariz y la boca ¡\nd) Todas las anteriores!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:17:46Z",
-      "updated_at": "2020-03-22T21:16:10Z",
       "language": "es"
     },
     {
-      "id": 4298,
       "label": "covid_prev_fact_1",
       "translation": "HECHO: Actualmente no existe una vacuna contra el virus, por lo cual el distanciamiento social y la buena higiene de las manos son tan cruciales para evitar enfermarse.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:15:45Z",
-      "updated_at": "2020-03-21T01:16:26Z",
       "language": "es"
     },
     {
-      "id": 4297,
       "label": "covid_prev_fact_1",
       "translation": "LES FAITS: Il n’y a pas de vaccin contre le coronavirus aujourd’hui. C’est pour cela que la distanciation sociale et le lavage des mains régulier sont si importants pour éviter de tomber malade. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:15:34Z",
-      "updated_at": "2020-03-21T01:16:31Z",
       "language": "fr"
     },
     {
-      "id": 4296,
       "label": "covid_prev_fact_1",
       "translation": "目前还没有针对 2019 新型冠状病毒(COVID-19) 的疫苗。这也是和所有人保持距离和正确洗手尤其重要的原因。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:15:27Z",
-      "updated_at": "2020-03-21T01:16:45Z",
       "language": "zh"
     },
     {
-      "id": 4301,
       "label": "covid_prev_practice_2",
       "translation": "Quel est le meilleur moyen de se protéger face au COVID-19? \n\na) Maintenir une distance entre chaque personne \nb) Se laver les mains fréquemment\nc) Éviter de se toucher les yeux, le nez et la bouche \nd) Toutes les options ci-dessus\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:18:09Z",
-      "updated_at": "2020-03-22T21:16:33Z",
       "language": "fr"
     },
     {
-      "id": 4299,
       "label": "covid_prev_practice_2",
       "translation": "What is the best way to avoid exposure to COVID-19?\n\na) Maintain a social distance\nb) Wash your hands frequently\nc) Avoid touching your eyes, nose, and mouth\nd) All of the above\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:17:05Z",
-      "updated_at": "2020-03-22T21:17:17Z",
       "language": "en"
     },
     {
-      "id": 4302,
       "label": "covid_prev_practice_2",
       "translation": "避免接触 2019 新型冠状病毒(COVID-19)的最佳方式是什么？\nA）和所有人保持2米的距离\nB）勤洗手\nC）不要碰眼睛、鼻子和嘴\nD）以上全部选项\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:19:10Z",
-      "updated_at": "2020-03-21T01:19:10Z",
       "language": "zh"
     },
     {
-      "id": 4303,
       "label": "covid_prev_fact_2",
       "translation": "FACT: COVID-19 is primarily spread through the air and respiratory system. It is important to keep distance from others, wash your hands, and to not touch your face.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:20:03Z",
-      "updated_at": "2020-03-21T01:20:09Z",
       "language": "en"
     },
     {
-      "id": 4304,
       "label": "covid_prev_fact_2",
       "translation": "2019 新型冠状病毒 (COVID-19) 主要作用于呼吸系统。和他人保持距离，勤洗手，和尽量不摸脸，都是很重要的。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:20:22Z",
-      "updated_at": "2020-03-21T01:20:37Z",
       "language": "zh"
     },
     {
-      "id": 4306,
       "label": "covid_prev_fact_2",
       "translation": "HECHO: COVID-19 se transmite principalmente a través del aire y el sistema respiratorio. Es importante mantener distancia de los demás, lavarse las manos y no tocarse la cara.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:21:14Z",
-      "updated_at": "2020-03-21T01:21:14Z",
       "language": "es"
     },
     {
-      "id": 4307,
       "label": "covid_prev_practice_3",
       "translation": "When do symptoms of COVID-19 typically appear?\n\na) Immediately after exposure\nb) 12 hours after exposure\nc) 2-14 days after exposure\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:22:07Z",
-      "updated_at": "2020-03-21T01:22:19Z",
       "language": "en"
     },
     {
-      "id": 4308,
       "label": "covid_prev_practice_3",
       "translation": "¿Cuándo aparecen típicamente los síntomas deL COVID-19?\n\na) Inmediatamente después de exposición\nb) 12 horas después de exposición\nc) 2-14 días después de exposición\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:22:39Z",
-      "updated_at": "2020-03-21T01:22:39Z",
       "language": "es"
     },
     {
-      "id": 4309,
       "label": "covid_prev_practice_3",
       "translation": "Quand apparaissent les symptômes du COVID-19? \n\na) Immédiatement après y avoir été exposé\nb) 12 heures après y avoir été exposé\nc) 2 à 14 jours après y avoir été exposé\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:22:49Z",
-      "updated_at": "2020-03-21T01:23:20Z",
       "language": "fr"
     },
     {
-      "id": 4310,
       "label": "covid_prev_practice_3",
       "translation": "2019 新型冠状病毒(COVID-19)的潜伏期（从暴露于病毒到出现症状的时间）有多长？\nA）几个小时\nB）12 小时\nC）2 - 14 天\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:23:29Z",
-      "updated_at": "2020-03-21T01:23:29Z",
       "language": "zh"
     },
     {
-      "id": 4311,
       "label": "covid_prev_fact_3",
       "translation": "FACT: COVID-19 can be spread by people who are showing no symptoms of sickness. Keep a social distance to avoid getting infected or infecting others. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:24:01Z",
-      "updated_at": "2020-03-21T01:24:13Z",
       "language": "en"
     },
     {
-      "id": 4312,
       "label": "covid_prev_fact_3",
       "translation": "2019 新型冠状病毒(COVID-19)可以通过无症状的感染者进行传播，所以即便他人没有症状，也要记住保持距离。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:24:31Z",
-      "updated_at": "2020-03-21T01:24:31Z",
       "language": "zh"
     },
     {
-      "id": 4314,
       "label": "covid_prev_fact_3",
       "translation": "HECHO: COVID-19 puede transmitirse por personas que no muestran síntomas de la enfermedad. Mantenga una distancia social para evitar infectarse o infectar a otros. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:24:56Z",
-      "updated_at": "2020-03-21T01:24:56Z",
       "language": "es"
     },
     {
-      "id": 4315,
       "label": "covid_prev_practice_4",
       "translation": "When should you wear a mask?\n\na) if you are coughing or sneezing\nb) if you are showing the symptoms of COVID-19\nc) if you are taking care of someone suspected of having COVID-19\nd) all of the above\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:25:21Z",
-      "updated_at": "2020-03-21T01:25:27Z",
       "language": "en"
     },
     {
-      "id": 4316,
       "label": "covid_prev_practice_4",
       "translation": "¿Cuándo debe usar una máscara?\n\na) si está tosiendo o estornudando\nb) si muestra los síntomas del COVID-19\nc) si está cuidando a alguien que se sospecha de tener COVID-19\nd) todas las anteriores\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:25:48Z",
-      "updated_at": "2020-03-21T01:26:26Z",
       "language": "es"
     },
     {
-      "id": 4318,
       "label": "covid_prev_practice_4",
       "translation": "在下面哪些情况下需要戴口罩？\nA）你咳嗽或打喷嚏的时候\nB）你出现了 2019 新型冠状病毒(COVID-19) 的症状\nC）你在照顾 2019 新型冠状病毒(COVID-19)的疑似感染者时\nD）以上全部选项\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:29:02Z",
-      "updated_at": "2020-03-21T01:29:02Z",
       "language": "zh"
     },
     {
-      "id": 4317,
       "label": "covid_prev_practice_4",
       "translation": "Quand devez-vous porter un masque? \n\na) Quand vous toussez ou éternuez\nb) Si vous avez les symptômes du COVID-19\nc) Si vous prenez soin de quelqu’un qui a peut-être le COVID-19\nd) Toutes les options ci-dessus \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:26:40Z",
-      "updated_at": "2020-03-21T01:28:43Z",
       "language": "fr"
     },
     {
-      "id": 4322,
       "label": "covid_prev_fact_4",
       "translation": "HECHO: Si está sano, solamente necesita usar una máscara si está cuidando a una persona con COVID-19.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:30:48Z",
-      "updated_at": "2020-03-24T03:49:55Z",
       "language": "es"
     },
     {
-      "id": 4323,
       "label": "covid_prev_practice_5",
       "translation": "Masks are only effective when they are combined with regular handwashing.\n\na) true\nb) false",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:31:15Z",
-      "updated_at": "2020-03-24T03:51:33Z",
       "language": "en"
     },
     {
-      "id": 4295,
       "label": "covid_prev_fact_1",
       "translation": "FACT: There is no vaccine to the virus currently, which is why social distancing and good hand hygiene are so critical to prevent coming ill.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:15:09Z",
-      "updated_at": "2020-03-22T21:14:35Z",
       "language": "en"
     },
     {
-      "id": 4313,
       "label": "covid_prev_fact_3",
       "translation": "LES FAITS: Le COVID-19 peut être transmis par des personnes qui n’ont pas de symptômes et ne se sentent pas malades. Pratiquez la distanciation sociale pour éviter d’être porteur et de le transmettre à d’autres.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:24:44Z",
-      "updated_at": "2020-03-22T21:20:19Z",
       "language": "fr"
     },
     {
-      "id": 4610,
-      "label": "at_least_sixty_percent",
-      "translation": "at least 60%",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:36:14Z",
-      "updated_at": "2020-03-23T20:36:59Z",
-      "language": "en"
-    },
-    {
-      "id": 4618,
-      "label": "percentage_alcohol_based",
-      "translation": "Ils contiennent entre 60 et 90% d’alcool",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:40:03Z",
-      "updated_at": "2020-03-23T20:40:03Z",
-      "language": "fr"
-    },
-    {
-      "id": 4615,
-      "label": "percentage_alcohol_based",
-      "translation": "are 60-90% alcohol-based  ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:39:37Z",
-      "updated_at": "2020-03-23T20:40:23Z",
-      "language": "en"
-    },
-    {
-      "id": 4620,
-      "label": "yes",
-      "translation": "yes",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:48:31Z",
-      "updated_at": "2020-03-23T20:48:31Z",
-      "language": "en"
-    },
-    {
-      "id": 4319,
       "label": "covid_prev_fact_4",
       "translation": "FACT: If you are healthy, you only need to wear a mask if you are taking care of a person with COVID-19.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:29:29Z",
-      "updated_at": "2020-03-24T03:49:49Z",
       "language": "en"
     },
     {
-      "id": 4321,
       "label": "covid_prev_fact_4",
       "translation": "LES FAITS: Si vous êtes en bonne santé, vous devez porter un masque uniquement si vous vous occupez d’une personne malade du COVID-19.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:30:22Z",
-      "updated_at": "2020-03-24T03:50:05Z",
       "language": "fr"
     },
     {
-      "id": 4320,
       "label": "covid_prev_fact_4",
       "translation": "如果你是健康的，那么只有在照顾 2019 新型冠状病毒(COVID-19) 病人时才需要戴口罩",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:30:06Z",
-      "updated_at": "2020-03-24T03:51:00Z",
       "language": "zh"
     },
     {
-      "id": 4337,
       "label": "hand_sani_practice_2",
       "translation": "Choisissez la meilleure option pour compléter la phrase. \n\nSi vous n’avez pas de savon et d’eau, utilisez un désinfectant pour les mains à base de [---] \n\na) D’eau de javel\nb) De savon \nc) D’alcool\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:43:29Z",
-      "updated_at": "2020-03-22T23:15:08Z",
       "language": "fr"
     },
     {
-      "id": 4331,
       "label": "hand_sani_fact_1",
       "translation": "FACT: Hand sanitizers can quickly reduce the microbes on your hands, but they do not eliminate all types of germs. Soap and water is more effective than hand sanitizers. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:40:21Z",
-      "updated_at": "2020-03-21T01:40:50Z",
       "language": "en"
     },
     {
-      "id": 4334,
       "label": "hand_sani_fact_1",
       "translation": "免洗洗手液能够迅速减少手上微生物的数量，但它并不能杀死所有细菌。用流水和香皂或洗手液洗手，要比用免洗洗手液更有效。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:41:27Z",
-      "updated_at": "2020-03-21T01:41:27Z",
       "language": "zh"
     },
     {
-      "id": 4333,
       "label": "hand_sani_fact_1",
       "translation": "LES FAITS: Les désinfectants pour les mains peuvent rapidement réduire les microbes sur vos mains mais ils n’éliminent pas tous les types de germes. Le savon et l’eau sont plus efficaces que les désinfectants.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:41:14Z",
-      "updated_at": "2020-03-21T01:41:40Z",
       "language": "fr"
     },
     {
-      "id": 4332,
       "label": "hand_sani_fact_1",
       "translation": "HECHO: Los desinfectantes de mano pueden rápidamente reducir los microbios en las manos pero no eliminan todo tipo de gérmenes. El agua y jabón son más efectivos que los desinfectantes de mano. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:41:05Z",
-      "updated_at": "2020-03-21T01:41:50Z",
       "language": "es"
     },
     {
-      "id": 4341,
       "label": "hand_sani_fact_2",
       "translation": "HECHO: Desinfectantes a base de alcohol, las cuales no requieren agua, son una alternativa aceptable cuando no se encuentran disponibles agua y jabón.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:45:59Z",
-      "updated_at": "2020-03-22T23:17:06Z",
       "language": "es"
     },
     {
-      "id": 4336,
       "label": "hand_sani_practice_2",
       "translation": "在没有流水和肥皂的情况下，可以选用下面哪种免洗洗手液？\n\nA）以漂白剂为主要成分的免洗洗手液\nB）以肥皂为主要成分的免洗洗手液\nC）以酒精为主要成分免洗洗手液\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:43:02Z",
-      "updated_at": "2020-03-21T01:43:02Z",
       "language": "zh"
     },
     {
-      "id": 4339,
       "label": "hand_sani_fact_2",
       "translation": "FACT: Alcohol-based hand sanitizers, which don't require water, are an acceptable alternative when soap and water aren't available.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:44:34Z",
-      "updated_at": "2020-03-21T01:44:45Z",
       "language": "en"
     },
     {
-      "id": 4340,
       "label": "hand_sani_fact_2",
       "translation": "LES FAITS: Les désinfectants à base d’alcool (gels hydroalcooliques) ne nécessitent pas d’eau et sont une alternative au savon quand celui-ci n’est pas disponible. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:45:37Z",
-      "updated_at": "2020-03-21T01:45:37Z",
       "language": "fr"
     },
     {
-      "id": 4342,
       "label": "hand_sani_fact_2",
       "translation": "以酒精为主要成分的免洗洗手液不需要用水冲洗。在无法使用流水和香皂的情况下，可以用酒精免洗洗手液来洗手。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:46:17Z",
-      "updated_at": "2020-03-21T01:46:17Z",
       "language": "zh"
     },
     {
-      "id": 4352,
       "label": "hand_sani_practice_4",
       "translation": "正确使用免洗洗手液的方式是将它涂满双手，并揉搓直到手变干为止。\n\na）正确\nb）错误",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:50:24Z",
-      "updated_at": "2020-03-22T23:22:06Z",
       "language": "zh"
     },
     {
-      "id": 4347,
       "label": "hand_sani_fact_3",
       "translation": "FACT: Sanitizers with an alcohol concentration between 60–95% are more effective at killing germs than those with a less alcohol concentration.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:48:31Z",
-      "updated_at": "2020-03-21T01:48:38Z",
       "language": "en"
     },
     {
-      "id": 4361,
       "label": "hand_sani_practice_5",
       "translation": "Les désinfectants avec un parfum peuvent être utilisés seulement si [---]\n\na) Ils contiennent des ingrédients organiques\nb) Ils contiennent des anticorps\nc) Ils sentent bon\nd) Ils contiennent entre 60 et 90% d’alcool\ne) Toutes les réponses ci-dessus\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:54:50Z",
-      "updated_at": "2020-03-21T01:54:50Z",
       "language": "fr"
     },
     {
-      "id": 4327,
       "label": "hand_sani_practice_1",
       "translation": "Hand sanitizers eliminate all types of germs. \n\na) true\nb) false",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:36:30Z",
-      "updated_at": "2020-03-24T00:03:49Z",
       "language": "en"
     },
     {
-      "id": 4330,
       "label": "hand_sani_practice_1",
       "translation": "Los desinfectantes de mano eliminan todo tipo de gérmenes. \n\na) cierto\nb) falso\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:39:57Z",
-      "updated_at": "2020-03-24T00:03:54Z",
       "language": "es"
     },
     {
-      "id": 4329,
       "label": "hand_sani_practice_1",
       "translation": "Les désinfectants pour les mains éliminent tous les types de germes. \n\na) Vrai \nb) Faux\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:39:21Z",
-      "updated_at": "2020-03-24T00:04:00Z",
       "language": "fr"
     },
     {
-      "id": 4335,
       "label": "hand_sani_practice_2",
       "translation": "Choose the best option to fill in the space. \n\nIf soap and water are not available, use an [---] hand sanitizer. \n \na) bleach-based\nb) soap-based\nc) alcohol-based",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:42:30Z",
-      "updated_at": "2020-03-22T23:14:18Z",
       "language": "en"
     },
     {
-      "id": 4338,
       "label": "hand_sani_practice_2",
       "translation": "Escoja la mejor opción para llenar el blanco. \n\nSi no hay agua y jabón disponibles, use desinfectante de manos [---]. \n \na) a base de lejía\nb) a base de jabón\nc) a base de alcohol",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:44:05Z",
-      "updated_at": "2020-03-22T23:14:28Z",
       "language": "es"
     },
     {
-      "id": 4324,
       "label": "covid_prev_practice_5",
       "translation": "Las máscaras solamente son efectivas cuando también se lava las manos regularmente.\n\na) cierto\nb) falso\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:32:03Z",
-      "updated_at": "2020-03-24T03:51:43Z",
       "language": "es"
     },
     {
-      "id": 4345,
       "label": "hand_sani_practice_3",
       "translation": "Répondez à cette question. \n\nQuand vous utilisez un gel hydroalcoolique, il faut qu’il contienne [---] d’alcool\n\na) Au moins 30%\nb) Au moins 60%\nc) 90% ou plus \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:47:41Z",
-      "updated_at": "2020-03-22T23:18:30Z",
       "language": "fr"
     },
     {
-      "id": 4343,
       "label": "hand_sani_practice_3",
       "translation": "Answer the question.\n\nWhen you use alcohol-based hand sanitizer, make sure it contains [---] alcohol.\n \na) at least 30%\nb) at least 60% \nc) only 90% or higher",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:46:41Z",
-      "updated_at": "2020-03-22T23:18:38Z",
       "language": "en"
     },
     {
-      "id": 4325,
       "label": "covid_prev_practice_5",
       "translation": "Les masques sont efficaces quand ils sont doublés d’un lavage de main régulier.\n\na) Vrai \nb) Faux\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:32:31Z",
-      "updated_at": "2020-03-24T03:51:55Z",
       "language": "fr"
     },
     {
-      "id": 4326,
       "label": "covid_prev_practice_5",
       "translation": "戴口罩也不能忘了勤洗手，二者结合才能起作用。\n\na）正确\nb）错误\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:32:45Z",
-      "updated_at": "2020-03-24T03:52:15Z",
       "language": "zh"
     },
     {
-      "id": 4328,
       "label": "hand_sani_practice_1",
       "translation": "免洗洗手液可以清楚所有种类的细菌。\n\na）正确\nb）错误\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:38:39Z",
-      "updated_at": "2020-03-24T00:04:12Z",
       "language": "zh"
     },
     {
-      "id": 4362,
       "label": "hand_sani_practice_5",
       "translation": "Los desinfectantes perfumados son aceptables siempre y cuando [---].\n\na) utilicen ingredientes orgánicos\nb) contengan anticuerpos\nc) huelan bien\nd) sean 60-90% a base de alcohol \ne) todo lo anterior",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:55:32Z",
-      "updated_at": "2020-03-24T01:11:30Z",
       "language": "es"
     },
     {
-      "id": 4344,
       "label": "hand_sani_practice_3",
       "translation": "以酒精为主要成分免洗洗手液，要有多少酒精含量才足够有效？\n\nA）30% 以上\nB）60% 以上\nC）90% 以上",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:47:19Z",
-      "updated_at": "2020-03-24T07:08:26Z",
       "language": "zh"
     },
     {
-      "id": 4348,
       "label": "hand_sani_fact_3",
       "translation": "HECHO: Los desinfectantes con una concentración de alcohol entre 60-95% son más efectivos en contra de los gérmenes que aquellos con una menor concentración de alcohol. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:48:56Z",
-      "updated_at": "2020-03-21T01:48:56Z",
       "language": "es"
     },
     {
-      "id": 4349,
       "label": "hand_sani_fact_3",
       "translation": "LES FAITS: Les gels hydroalcooliques qui contiennent entre 60 et 95% d’alcool sont les plus efficaces pour tuer les germes. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:49:16Z",
-      "updated_at": "2020-03-21T01:49:16Z",
       "language": "fr"
     },
     {
-      "id": 4350,
       "label": "hand_sani_fact_3",
       "translation": "酒精含量在 60% 到 95% 之间的免洗洗手液能够最有效地抑制细菌。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:49:30Z",
-      "updated_at": "2020-03-21T01:49:30Z",
       "language": "zh"
     },
     {
-      "id": 4351,
       "label": "hand_sani_practice_4",
       "translation": "To use hand sanitizer correctly, rub it all over the surfaces of your hands until your hands are dry.\n\na) true\nb) false",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:49:58Z",
-      "updated_at": "2020-03-21T01:50:10Z",
       "language": "en"
     },
     {
-      "id": 4355,
       "label": "hand_sani_fact_4",
       "translation": "FACT: Rub sanitizer on your hands until your hands are dry. But remember that it will only reduce the growth of germs. It will not kill them outright.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:51:43Z",
-      "updated_at": "2020-03-21T01:51:55Z",
       "language": "en"
     },
     {
-      "id": 4356,
       "label": "hand_sani_fact_4",
       "translation": "HECHO: Frote el desinfectante sobre sus manos hasta que éstas estén secas. Recuerde que esto solamente reducirá el crecimiento de gérmenes; no los matará por completo.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:52:14Z",
-      "updated_at": "2020-03-21T01:52:14Z",
       "language": "es"
     },
     {
-      "id": 4359,
       "label": "hand_sani_practice_5",
       "translation": "Scented sanitizers are ok to use only if they [---].\n\na) use organic ingredients\nb) contain antibodies\nc) smell good\nd) are 60-90% alcohol-based \ne) all of the above",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:53:34Z",
-      "updated_at": "2020-03-21T01:53:43Z",
       "language": "en"
     },
     {
-      "id": 4360,
       "label": "hand_sani_practice_5",
       "translation": "满足哪个条件才是合格有效的免洗洗手液。\nA）来自有机原料\nB）含有病菌抗体\nC）香味好闻\nD）酒精含量在 60% - 90%之间\nE）以上全部选项\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:54:06Z",
-      "updated_at": "2020-03-21T01:54:06Z",
       "language": "zh"
     },
     {
-      "id": 4364,
       "label": "disinfect_phone_practice_1",
       "translation": "大约 80% 的传染病病例是通过哪个传播途径被感染的？\n\nA）手部接触传播\nB）咳嗽飞沫传播\nC）喷嚏飞沫传播\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:00:21Z",
-      "updated_at": "2020-03-21T02:00:21Z",
       "language": "zh"
     },
     {
-      "id": 4346,
       "label": "hand_sani_practice_3",
       "translation": "Contesta la pregunta.\n\nCuando use desinfectante de manos a base de alcohol, asegúrese de que contenga [---] de alcohol.\n \na) al menos 30%\nb) al menos 60% \nc) solamente 90% o más",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:48:07Z",
-      "updated_at": "2020-03-22T23:18:44Z",
       "language": "es"
     },
     {
-      "id": 4353,
       "label": "hand_sani_practice_4",
       "translation": "Pour utiliser un désinfectant correctement, il faut en mettre partout sur vos mains jusqu’à ce qu’elles soient sèches. \n\na) Vrai \nb) Faux",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:50:42Z",
-      "updated_at": "2020-03-22T23:21:52Z",
       "language": "fr"
     },
     {
-      "id": 4358,
       "label": "hand_sani_fact_4",
       "translation": "用免洗洗手液时，要一直揉搓到手干了为止。但要记住，它能够抑制细菌滋生，但并不会完全杀灭所有细菌。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:52:41Z",
-      "updated_at": "2020-03-22T23:33:35Z",
       "language": "zh"
     },
     {
-      "id": 4354,
       "label": "hand_sani_practice_4",
       "translation": "Para usar el desinfectante de manos correctamente, restriegalo sobre las superficies de las manos hasta que estén secas.\n\na) verdadero\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:51:03Z",
-      "updated_at": "2020-03-23T20:41:18Z",
       "language": "es"
     },
     {
-      "id": 4363,
       "label": "disinfect_phone_practice_1",
       "translation": "80 percent of all infections are transmitted by [---]\n\na) hands\nb) coughing\nc) sneezing\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:59:53Z",
-      "updated_at": "2020-03-24T00:09:44Z",
       "language": "en"
     },
     {
-      "id": 4365,
       "label": "disinfect_phone_practice_1",
       "translation": "80% des infections sont transmises par [---]\n\na) Les mains\nb) La toux\nc) Les éternuements\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:01:25Z",
-      "updated_at": "2020-03-24T00:09:59Z",
       "language": "fr"
     },
     {
-      "id": 4357,
       "label": "hand_sani_fact_4",
       "translation": "LES FAITS: Frictionnez vos mains avec du désinfectant jusqu’à ce qu’elles soient sèches. N’oubliez pas que cela va seulement réduire la croissance des germes. Cela ne va pas tous les tuer. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:52:29Z",
-      "updated_at": "2020-03-21T01:52:29Z",
       "language": "fr"
     },
     {
-      "id": 4367,
       "label": "disinfect_phone_fact_1",
       "translation": "FACT: Our smartphones have become an extension of our hands, so it's important to sanitize them.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:02:32Z",
-      "updated_at": "2020-03-21T02:02:41Z",
       "language": "en"
     },
     {
-      "id": 4368,
       "label": "disinfect_phone_fact_1",
       "translation": "HECHO: Nuestros teléfonos inteligentes se han convertido en una extensión de nuestras manos, por lo que es importante desinfectarlos.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:02:58Z",
-      "updated_at": "2020-03-21T02:02:58Z",
       "language": "es"
     },
     {
-      "id": 4369,
       "label": "disinfect_phone_fact_1",
       "translation": "LES FAITS: Nos téléphones sont devenus une extension de nos mains donc il est très important de les désinfecter aussi. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:03:09Z",
-      "updated_at": "2020-03-21T02:03:09Z",
       "language": "fr"
     },
     {
-      "id": 4374,
       "label": "disinfect_phone_practice_2",
       "translation": "La pantalla promedio de un teléfono inteligente tiene más de tres veces el sucio de un asiento de inodoro. \n\na) verdadero\nb) cierto",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:05:01Z",
-      "updated_at": "2020-03-24T00:10:51Z",
       "language": "es"
     },
     {
-      "id": 4375,
       "label": "disinfect_phone_fact_2",
       "translation": "FACT: This makes cell phones one of the dirtiest objects we come in contact with every day.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:05:28Z",
-      "updated_at": "2020-03-21T02:05:35Z",
       "language": "en"
     },
     {
-      "id": 4377,
       "label": "disinfect_phone_fact_2",
       "translation": "LES FAITS: Nos téléphones sont l’objet le plus sale que nous touchons tous les jours. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:06:08Z",
-      "updated_at": "2020-03-21T02:06:08Z",
       "language": "fr"
     },
     {
-      "id": 4378,
       "label": "disinfect_phone_fact_2",
       "translation": "手机可能是我们日常生活种接触到的东西种最不干净的的一个。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:06:26Z",
-      "updated_at": "2020-03-21T02:06:26Z",
       "language": "zh"
     },
     {
-      "id": 4379,
       "label": "disinfect_phone_practice_3",
       "translation": "Are sanitizer wipes safe to use on your phone?\n\na) yes\nb) no",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:07:01Z",
-      "updated_at": "2020-03-21T02:07:07Z",
       "language": "en"
     },
     {
-      "id": 4383,
       "label": "disinfect_phone_fact_3",
       "translation": "FACT: Many sanitizer wipes are ok to use on Smartphones, Tablets and Remote Controls. Just be sure to check the sanitizer label first to confirm it's safe for that use! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:08:23Z",
-      "updated_at": "2020-03-21T02:08:32Z",
       "language": "en"
     },
     {
-      "id": 4384,
       "label": "disinfect_phone_fact_3",
       "translation": "HECHO: Muchas toallitas desinfectantes pueden usarse en teléfonos inteligentes, tabletas y controles remotos. ¡Solo asegúrese de primero revisar la etiqueta del desinfectante para confirmar que sea seguro para ese uso! \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:08:50Z",
-      "updated_at": "2020-03-21T02:08:50Z",
       "language": "es"
     },
     {
-      "id": 4385,
       "label": "disinfect_phone_fact_3",
       "translation": "LES FAITS: Beaucoup de lingettes désinfectantes peuvent être utilisées sur les smartphones, tablettes et télécommandes. Assurez-vous que cela est possible en lisant l’étiquette sur l’emballage. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:09:01Z",
-      "updated_at": "2020-03-21T02:09:01Z",
       "language": "fr"
     },
     {
-      "id": 4386,
       "label": "disinfect_phone_fact_3",
       "translation": "一般的消毒纸巾都可以擦拭手机、平板电脑和遥控器。请在使用前参考消毒纸巾的产品说明，以确保物品不会遭到损坏。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:09:17Z",
-      "updated_at": "2020-03-21T02:09:17Z",
       "language": "zh"
     },
     {
-      "id": 4387,
       "label": "disinfect_phone_practice_4",
       "translation": "Choose the best option to fill in the space. \n\nClean your phone while it is [---]\n\na) off \nb) unplugged\nc) off and unplugged",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:09:58Z",
-      "updated_at": "2020-03-22T23:52:12Z",
       "language": "en"
     },
     {
-      "id": 4391,
       "label": "disinfect_phone_fact_4",
       "translation": "FACT: Hand sanitizer, can easily get through small cracks and enter the interior of your phone. It can cause permanent damage. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:11:56Z",
-      "updated_at": "2020-03-21T02:12:02Z",
       "language": "en"
     },
     {
-      "id": 4392,
       "label": "disinfect_phone_fact_4",
       "translation": "HECHO: Desinfectante de manos, puede atravesar fácilmente pequeñas grietas e ingresar al interior de su teléfono. Puede causar daños permanentes. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:12:23Z",
-      "updated_at": "2020-03-21T02:12:23Z",
       "language": "es"
     },
     {
-      "id": 4393,
       "label": "disinfect_phone_fact_4",
       "translation": "LES FAITS: Les gels hydroalcooliques peuvent facilement pénétrer à l’intérieur de votre téléphone et les abîmer. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:12:36Z",
-      "updated_at": "2020-03-21T02:12:36Z",
       "language": "fr"
     },
     {
-      "id": 4395,
       "label": "disinfect_phone_practice_5",
       "translation": "The best way to use your phone in order to avoid the transmission of germs is [---]\n\na) avoid pressing your phone against your face\nb) use headphones\nc) use speakerphone when appropriate\nd) all of the above\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:13:19Z",
-      "updated_at": "2020-03-21T02:13:31Z",
       "language": "en"
     },
     {
-      "id": 4396,
       "label": "disinfect_phone_practice_5",
       "translation": "为了防止细菌和病毒的传播，使用手机要注意什么？\na）手机不要接触脸部\nb）用耳机打电话\nc）在不影响别人的情况下使用免提\nd）以上全部选项\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:13:42Z",
-      "updated_at": "2020-03-21T02:13:42Z",
       "language": "zh"
     },
     {
-      "id": 4370,
       "label": "disinfect_phone_fact_1",
       "translation": "现在大家都手机不离手，所以保持手机清洁正变得越来越重要。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:03:29Z",
-      "updated_at": "2020-03-22T23:44:49Z",
       "language": "zh"
     },
     {
-      "id": 4380,
       "label": "disinfect_phone_practice_3",
       "translation": "可以用消毒纸巾擦手机吗？\na）可以\nb）不可以",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:07:26Z",
-      "updated_at": "2020-03-24T07:10:01Z",
       "language": "zh"
     },
     {
-      "id": 4372,
       "label": "disinfect_phone_practice_2",
       "translation": "手机屏幕比马桶座还要脏 3 倍。\n\na）正确\nb）错误",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:04:23Z",
-      "updated_at": "2020-03-22T23:46:37Z",
       "language": "zh"
     },
     {
-      "id": 4376,
       "label": "disinfect_phone_fact_2",
       "translation": "HECHO: Por esta razón, los teléfonos celulares son uno de los objetos más sucios con los que interactuamos diariamente.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:05:52Z",
-      "updated_at": "2020-03-22T23:47:40Z",
       "language": "es"
     },
     {
-      "id": 4382,
       "label": "disinfect_phone_practice_3",
       "translation": "¿Es seguro usar toallitas desinfectantes en su teléfono? \n\na) sí\nb) no",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:07:59Z",
-      "updated_at": "2020-03-22T23:49:23Z",
       "language": "es"
     },
     {
-      "id": 4394,
       "label": "disinfect_phone_fact_4",
       "translation": "电子产品不防水的话，洗手液有可能渗透进它们内部，进而对设备造成损坏。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:12:48Z",
-      "updated_at": "2020-03-22T23:53:37Z",
       "language": "zh"
     },
     {
-      "id": 4389,
       "label": "disinfect_phone_practice_4",
       "translation": "Choisissez la meilleure option pour compléter la phrase.\n\nNettoyez votre téléphone quand il est [---]\n\na) Éteint\nb) Débranché\nc) Éteint et débranché ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:10:57Z",
-      "updated_at": "2020-03-24T02:59:09Z",
       "language": "fr"
     },
     {
-      "id": 4397,
       "label": "disinfect_phone_practice_5",
       "translation": "Quand on utilise son téléphone, la meilleure façon d’éviter la transmission de germes est  [---]\n\na) D’éviter de mettre son téléphone contre son visage\nb) D’utiliser des écouteurs\nc) D’utiliser son téléphone en haut parleur\nd) Toutes les réponses ci-dessus",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:14:29Z",
-      "updated_at": "2020-03-24T02:59:27Z",
       "language": "fr"
     },
     {
-      "id": 4398,
       "label": "disinfect_phone_practice_5",
       "translation": "La mejor manera de utilizar el teléfono con el fin de evitar la transmisión de gérmenes es [---]\n\na) evitar presionar el teléfono contra su cara\nb) auriculares uso\nc) uso altavoz cuando sea apropiado\nd) todo lo anterior",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:15:12Z",
-      "updated_at": "2020-03-22T23:56:28Z",
       "language": "es"
     },
     {
-      "id": 4381,
       "label": "disinfect_phone_practice_3",
       "translation": "Les lingettes désinfectantes peuvent-elles être utilisées pour désinfecter votre téléphone? \n\na) Oui\nb) Non",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:07:43Z",
-      "updated_at": "2020-03-24T03:19:59Z",
       "language": "fr"
     },
     {
-      "id": 4402,
       "label": "disinfect_phone_fact_5",
       "translation": "细菌和病毒可以在手机表面停留并存活三天以上。每次使用手机都可能接触到细菌和病毒。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:16:40Z",
-      "updated_at": "2020-03-22T23:58:40Z",
       "language": "zh"
     },
     {
-      "id": 4373,
       "label": "disinfect_phone_practice_2",
       "translation": "En moyenne, nos écrans de téléphones sont trois fois plus sales qu’un siège de toilette.\n\na) Vrai \nb) Faux ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:04:42Z",
-      "updated_at": "2020-03-24T00:10:56Z",
       "language": "fr"
     },
     {
-      "id": 4371,
       "label": "disinfect_phone_practice_2",
       "translation": "The average smartphone screen is more than three times dirtier than a toilet seat.\n\na) true\nb) false\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:03:59Z",
-      "updated_at": "2020-03-24T00:10:39Z",
       "language": "en"
     },
     {
-      "id": 4388,
       "label": "disinfect_phone_practice_4",
       "translation": "什么时候清洁手机最安全？\na）手机关机时\nb）手机不在充电时\nc）手机关机并且不在充电时",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:10:28Z",
-      "updated_at": "2020-03-24T07:10:14Z",
       "language": "zh"
     },
     {
-      "id": 4399,
       "label": "disinfect_phone_fact_5",
       "translation": "FACT: Phones hold germs on their surface for 3+ days. Everytime you touch your phone, you run the risk of getting sick. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:15:38Z",
-      "updated_at": "2020-03-21T02:15:46Z",
       "language": "en"
     },
     {
-      "id": 4407,
       "label": "high_contact_fact_1",
       "translation": "FACT: Early findings suggest the COVID-19 virus can survive on door handles, plastic-coated or laminated worktops and other hard surfaces.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:21:28Z",
-      "updated_at": "2020-03-23T01:00:47Z",
       "language": "en"
     },
     {
-      "id": 4400,
       "label": "disinfect_phone_fact_5",
       "translation": "HECHO: Móviles sostienen los gérmenes en su superficie para 3+ días. Cada vez que toca su teléfono, corre el riesgo de enfermarse.  \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:16:13Z",
-      "updated_at": "2020-03-22T23:58:18Z",
       "language": "es"
     },
     {
-      "id": 4401,
       "label": "disinfect_phone_fact_5",
       "translation": "LES FAITS: Les germes restent sur les surfaces des téléphones pendant plus de 3 jours. À chaque fois que nous les touchons, nous prenons le risque de tomber malade. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:16:25Z",
-      "updated_at": "2020-03-21T02:16:25Z",
       "language": "fr"
     },
     {
-      "id": 4403,
       "label": "high_contact_practice_1",
       "translation": "COVID19 cannot survive on material surfaces.\n\na) true\nb) false",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:19:51Z",
-      "updated_at": "2020-03-21T02:19:57Z",
       "language": "en"
     },
     {
-      "id": 4405,
       "label": "high_contact_practice_1",
       "translation": "Le COVID19 ne peut pas survivre sur les surfaces.\n\na) Vrai \nb) Faux \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:20:37Z",
-      "updated_at": "2020-03-23T00:58:24Z",
       "language": "fr"
     },
     {
-      "id": 4404,
       "label": "high_contact_practice_1",
       "translation": "2019 新型冠状病毒(COVID-19) 无法在物体表面存活。\na）正确\nb）错误",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:20:14Z",
-      "updated_at": "2020-03-24T07:11:32Z",
       "language": "zh"
     },
     {
-      "id": 4410,
       "label": "high_contact_fact_1",
       "translation": "2019 新型冠状病毒(COVID-19) 能够在门把手，塑料和工作台等坚硬表面存活。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:22:44Z",
-      "updated_at": "2020-03-21T02:22:44Z",
       "language": "zh"
     },
     {
-      "id": 4417,
       "label": "high_contact_fact_2",
       "translation": "LES FAITS: Les recherches actuelles montrent que le COVID-19 peut rester sur les objets et les surfaces de quelques heures à plusieurs jours.  \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:26:45Z",
-      "updated_at": "2020-03-23T01:03:57Z",
       "language": "fr"
     },
     {
-      "id": 4412,
       "label": "high_contact_practice_2",
       "translation": "桌面、门把手、开关、灶台、桌面、手机、键盘、厕所、水龙头和洗手池都属于那种分类？\na）高频接触的物体表面\nb）不经常接触的物体表面\nc）不会变脏的物体表面\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:24:22Z",
-      "updated_at": "2020-03-21T02:24:22Z",
       "language": "zh"
     },
     {
-      "id": 4413,
       "label": "high_contact_practice_2",
       "translation": "Choisissez la meilleure option pour compléter la phrase. \n\nLes tables, poignées de porte, interrupteurs, rampes, bureaux, téléphones, claviers, toilettes, éviers, robinets sont [---]\n\na) Des surfaces de contact faible\nb) Des surfaces de contact élevé\nc) Jamais sales\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:24:57Z",
-      "updated_at": "2020-03-21T02:24:57Z",
       "language": "fr"
     },
     {
-      "id": 4414,
       "label": "high_contact_practice_2",
       "translation": "Elija la mejor opción para llenar el blanco. \n\nLas mesas, perillas, interruptores de luz, encimeras, manijas, escritorios, teléfonos, teclados, inodoros, grifos, lavabos son [---]\n\na) superficies de bajo contacto\nb) superficies de alto contacto\nc) nunca sucias\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:25:25Z",
-      "updated_at": "2020-03-21T02:25:25Z",
       "language": "es"
     },
     {
-      "id": 4424,
       "label": "high_contact_fact_3",
       "translation": "HECHO: Después de tocar el cartón de las entregas, siempre debería lavarse las manos. Los guantes no evitarán el contagio. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:30:13Z",
-      "updated_at": "2020-03-23T01:07:07Z",
       "language": "es"
     },
     {
-      "id": 4418,
       "label": "high_contact_fact_2",
       "translation": "研究表明2019 新型冠状病毒(COVID-19)能够在物品表面存活数小时到数天时间\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:27:02Z",
-      "updated_at": "2020-03-21T02:27:02Z",
       "language": "zh"
     },
     {
-      "id": 4419,
       "label": "high_contact_practice_3",
       "translation": "Choose the best option to fill in the space.\n\nCOVID-19 can survive on cardboard for [---].\n\na) up to 24 hours\nb) 2-3 days\nc) 1 week",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:27:35Z",
-      "updated_at": "2020-03-23T01:05:59Z",
       "language": "en"
     },
     {
-      "id": 4423,
       "label": "high_contact_fact_3",
       "translation": "FACT: After touching cardboard from deliveries, you should always wash your hands. Gloves will not prevent the spread. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:29:48Z",
-      "updated_at": "2020-03-21T02:29:55Z",
       "language": "en"
     },
     {
-      "id": 4425,
       "label": "high_contact_fact_3",
       "translation": "LES FAITS: Après avoir touché des emballages en carton lors des livraisons, il faut impérativement se laver les mains. Les gants ne suffisent pas pour empêcher la propagation du virus.  \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:30:34Z",
-      "updated_at": "2020-03-21T02:30:34Z",
       "language": "fr"
     },
     {
-      "id": 4426,
       "label": "high_contact_fact_3",
       "translation": "在接触快递的纸箱后，应该按正确的方式洗手，即便带了手套也不能省略。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:30:48Z",
-      "updated_at": "2020-03-21T02:30:48Z",
       "language": "zh"
     },
     {
-      "id": 4429,
       "label": "high_contact_practice_4",
       "translation": "Le COVID-19 peut survivre sur des surfaces en plastique ou métal [---]\n\na) Jusqu’à 24h\nb) Pendant 2 à 3 jours\nc) Pendant une semaine\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:32:27Z",
-      "updated_at": "2020-03-23T01:08:15Z",
       "language": "fr"
     },
     {
-      "id": 4428,
       "label": "high_contact_practice_4",
       "translation": "2019 新型冠状病毒(COVID-19)能够在塑料表面和不锈钢表面能够存活多长时间？\nA）少于 24 小时\nB）两三天\nC）一周\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:31:55Z",
-      "updated_at": "2020-03-21T02:31:55Z",
       "language": "zh"
     },
     {
-      "id": 4431,
       "label": "high_contact_fact_4",
       "translation": "FACT: Clothing and other soft surfaces are harder to disinfect, it is not yet clear how long the virus can survive on the materials. Do not shake dirty laundry.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:33:21Z",
-      "updated_at": "2020-03-21T02:33:28Z",
       "language": "en"
     },
     {
-      "id": 4432,
       "label": "high_contact_fact_4",
       "translation": "HECHO: La ropa y otras superficies suaves son más difíciles de desinfectar, aún no se sabe cuánto tiempo el virus puede sobrevivir en estos materiales. No sacuda la ropa sucia. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:33:54Z",
-      "updated_at": "2020-03-21T02:33:54Z",
       "language": "es"
     },
     {
-      "id": 4433,
       "label": "high_contact_fact_4",
       "translation": "LES FAITS: Les vêtements et autres surfaces souples sont difficiles à désinfecter. Nous ne savons pas exactement combien de temps le virus peut survivre sur ces matériaux mais nous vous recommandons de ne pas secouer du linge sale. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:34:06Z",
-      "updated_at": "2020-03-21T02:34:06Z",
       "language": "fr"
     },
     {
-      "id": 4434,
       "label": "high_contact_fact_4",
       "translation": "衣物布料等粗糙表面不容易进行表面清洁。目前尚不清楚病毒可以在衣物中存活多长时间。清洗衣物时，请勿抖甩衣物。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:34:18Z",
-      "updated_at": "2020-03-21T02:34:18Z",
       "language": "zh"
     },
     {
-      "id": 4435,
       "label": "high_contact_practice_5",
-      "translation": "To prevent the spread of COVID-19 through high-contact surfaces, you should [---] them frequently. Use a bleach and water solution or other household sanitizing solution. \n\na) clean & disinfect\nb) aerate\nc) wipe them down ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:34:48Z",
-      "updated_at": "2020-03-21T02:34:54Z",
+      "translation": "To prevent the spread of COVID-19 through high-contact surfaces, you should [---] them frequently. Use a bleach and water solution or other household sanitizing solution. \n\na) clean \u0026 disinfect\nb) aerate\nc) wipe them down ",
       "language": "en"
     },
     {
-      "id": 4436,
       "label": "high_contact_practice_5",
       "translation": "为了防止 2019 新型冠状病毒(COVID-19) 通过高频接触的物品表面传播，你应该用家用清洁剂或消毒水来怎样处理它们？\nA）清洁并消毒\nB）对物品通风透气\nC）擦拭物品\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:35:12Z",
-      "updated_at": "2020-03-21T02:35:12Z",
       "language": "zh"
     },
     {
-      "id": 4438,
       "label": "high_contact_practice_5",
       "translation": "Para evitar la propagación del COVID-19 mediante superficies de alto contacto, debe [---] los con frecuencia. Use una solución de cloro y agua u otra solución desinfectante doméstica.. \n\na) limpiar y desinfectar\nb) airear\nc) desempolvar  \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:35:57Z",
-      "updated_at": "2020-03-21T02:35:57Z",
       "language": "es"
     },
     {
-      "id": 4408,
       "label": "high_contact_fact_1",
       "translation": "HECHO: Los primeros resultados sugieren que el virus COVID-19 puede durar tanto tiempo en manijas de puertas, encimeras de plástico revestido o laminado y otras superficies duras. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:21:58Z",
-      "updated_at": "2020-03-23T01:00:53Z",
       "language": "es"
     },
     {
-      "id": 4411,
       "label": "high_contact_practice_2",
       "translation": "Choose the best option to fill in the space.\n\nTables, doorknobs, light switches, countertops, handles, desks, phones, keyboards, toilets, faucets, sinks are [---]\n\na) low-contact surfaces\nb) high-contact surfaces\nc) never dirty",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:23:20Z",
-      "updated_at": "2020-03-23T01:01:48Z",
       "language": "en"
     },
     {
-      "id": 4416,
       "label": "high_contact_fact_2",
       "translation": "HECHO: Evidencia actual sugiere que COVID-19 puede permanecer en las superficies entre horas y días. \n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:26:31Z",
-      "updated_at": "2020-03-23T01:04:04Z",
       "language": "es"
     },
     {
-      "id": 4415,
       "label": "high_contact_fact_2",
       "translation": "FACT: Current evidence suggests that COVID-19 may remain on surfaces for hours to days.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:25:57Z",
-      "updated_at": "2020-03-23T01:04:22Z",
       "language": "en"
     },
     {
-      "id": 4421,
       "label": "high_contact_practice_3",
       "translation": "Choisissez la meilleure option pour compléter la phrase.\n\nLe COVID-19 peut survivre sur du carton [---]\na) Jusqu’à 24h\nb) Pendant 2 à 3 jours\nc) Pendant 1 semaine",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:28:56Z",
-      "updated_at": "2020-03-23T01:06:15Z",
       "language": "fr"
     },
     {
-      "id": 4422,
       "label": "high_contact_practice_3",
       "translation": "Elija la mejor opción para llenar el blanco.\n\nCOVID-19 puede sobrevivir en cartón por [---].\n\na) hasta 24 horas\nb) 2-3 días\nc) 1 semana",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:29:25Z",
-      "updated_at": "2020-03-23T01:06:06Z",
       "language": "es"
     },
     {
-      "id": 4427,
       "label": "high_contact_practice_4",
       "translation": "COVID-19 can survive on plastic and stainless steel surfaces for [---].\n\na) up to 24 hours\nb) 2-3 days\nc) 1 week",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:31:27Z",
-      "updated_at": "2020-03-23T01:07:38Z",
       "language": "en"
     },
     {
-      "id": 4430,
       "label": "high_contact_practice_4",
       "translation": "COVID-19 puede sobrevivir en superficies de plástico y acero inoxidable por [---].\n\na) hasta 24 horas\nb) 2-3 días\nc) 1 semana\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:32:58Z",
-      "updated_at": "2020-03-23T01:08:04Z",
       "language": "es"
     },
     {
-      "id": 4420,
       "label": "high_contact_practice_3",
       "translation": "2019 新型冠状病毒(COVID-19)能够在纸箱上能够存活多长时间？\nA）少于 24 小时\nB）两三天\nC）一周",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:28:24Z",
-      "updated_at": "2020-03-24T07:11:50Z",
       "language": "zh"
     },
     {
-      "id": 4261,
       "label": "stop_covid_thanks",
       "translation": "Thank you for dedicating your time to StopCovid training. By completing one training everyday, you are helping prevent the spread of Coronavirus. \n\nTogether, we will stop COVID-19.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T20:49:01Z",
-      "updated_at": "2020-03-21T19:08:43Z",
       "language": "en"
     },
     {
-      "id": 4470,
       "label": "covid_1_practice_2",
       "translation": "Escolha a melhor opção para preencher o espaço em branco. \n\nCOVID-19 é [---] a gripe. \n\na) contagioso quanto\nb) menos contagioso que\nc) mais contagioso que",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:27:56Z",
-      "updated_at": "2020-03-23T01:48:55Z",
       "language": "pt"
     },
     {
-      "id": 4238,
       "label": "covid_1_practice_3",
       "translation": "Answer the question. \n\nHow is COVID-19 spread from person to person?\n\na) Contact with an infected person\nb) An infected person coughs or sneezes \nc) Touching a surface with COVID-19 on it, then touching your face\nd) All of the above",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:52:40Z",
-      "updated_at": "2020-03-23T01:54:46Z",
       "language": "en"
     },
     {
-      "id": 4442,
       "label": "covid_1_title",
       "translation": "2019 新型冠状病毒(COVID-19)：你需要知道的",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:47:31Z",
-      "updated_at": "2020-03-21T23:47:31Z",
       "language": "zh"
     },
     {
-      "id": 4444,
       "label": "covid_2_title",
       "translation": "COVID-19 Prevención",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:50:15Z",
-      "updated_at": "2020-03-24T00:36:43Z",
       "language": "es"
     },
     {
-      "id": 4446,
       "label": "covid_2_title",
       "translation": "2019 新型冠状病毒(COVID-19)：预防措施",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:50:47Z",
-      "updated_at": "2020-03-21T23:50:47Z",
       "language": "zh"
     },
     {
-      "id": 4447,
       "label": "covid_4_title",
       "translation": "Hand sanitizer best practices",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:52:21Z",
-      "updated_at": "2020-03-21T23:52:53Z",
       "language": "en"
     },
     {
-      "id": 4448,
       "label": "covid_4_title",
       "translation": "Mejores prácticas con desinfectantes de mano",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:52:57Z",
-      "updated_at": "2020-03-21T23:52:57Z",
       "language": "es"
     },
     {
-      "id": 4449,
       "label": "covid_4_title",
       "translation": "Tout savoir sur les désinfectants pour les mains ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:53:17Z",
-      "updated_at": "2020-03-21T23:53:17Z",
       "language": "fr"
     },
     {
-      "id": 4450,
       "label": "covid_4_title",
       "translation": "免洗洗手液的正确使用方式",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:53:35Z",
-      "updated_at": "2020-03-21T23:53:35Z",
       "language": "zh"
     },
     {
-      "id": 4451,
       "label": "covid_5_title",
       "translation": "How to disinfect your phone",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:54:23Z",
-      "updated_at": "2020-03-21T23:54:43Z",
       "language": "en"
     },
     {
-      "id": 4452,
       "label": "covid_5_title",
       "translation": "Cómo desinfectar su teléfono",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:54:46Z",
-      "updated_at": "2020-03-21T23:54:46Z",
       "language": "es"
     },
     {
-      "id": 4453,
       "label": "covid_5_title",
       "translation": "Comment désinfecter votre téléphone",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:55:12Z",
-      "updated_at": "2020-03-21T23:55:12Z",
       "language": "fr"
     },
     {
-      "id": 4454,
       "label": "covid_5_title",
       "translation": "如何给手机消毒",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:55:24Z",
-      "updated_at": "2020-03-21T23:55:24Z",
       "language": "zh"
     },
     {
-      "id": 4456,
       "label": "covid_7_title",
       "translation": "Desinfección de superficies de alto contacto",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:57:01Z",
-      "updated_at": "2020-03-21T23:57:01Z",
       "language": "es"
     },
     {
-      "id": 4455,
       "label": "covid_7_title",
       "translation": "Sanitizing High-Contact Surfaces",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:56:42Z",
-      "updated_at": "2020-03-21T23:57:14Z",
       "language": "en"
     },
     {
-      "id": 4457,
       "label": "covid_7_title",
       "translation": "Désinfecter les surfaces très utilisées",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:57:26Z",
-      "updated_at": "2020-03-21T23:57:26Z",
       "language": "fr"
     },
     {
-      "id": 4458,
       "label": "covid_7_title",
       "translation": "清洁“高频接触”的物体表面",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:57:36Z",
-      "updated_at": "2020-03-21T23:57:36Z",
       "language": "zh"
     },
     {
-      "id": 4471,
       "label": "covid_1_fact_2",
       "translation": "FATO: COVID-19 é mais contagioso e mais mortal que a gripe. É importante que todos trabalhemos juntos para controlar sua propagação e salvar vidas.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:29:50Z",
-      "updated_at": "2020-03-22T20:29:50Z",
       "language": "pt"
     },
     {
-      "id": 4443,
       "label": "covid_2_title",
       "translation": "COVID-19 Prevention",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:49:42Z",
-      "updated_at": "2020-03-24T05:38:51Z",
       "language": "en"
     },
     {
-      "id": 4460,
-      "label": "this_is_test",
-      "translation": "this is test",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T19:10:08Z",
-      "updated_at": "2020-03-22T19:10:08Z",
-      "language": "en"
-    },
-    {
-      "id": 4462,
       "label": "covid_1_title",
       "translation": "O que você precisa saber sobre o COVID-19",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:05:44Z",
-      "updated_at": "2020-03-23T22:55:47Z",
       "language": "pt"
     },
     {
-      "id": 4461,
       "label": "drill_intro_2",
       "translation": "O exercício de hoje é: ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:04:43Z",
-      "updated_at": "2020-03-22T20:04:43Z",
       "language": "pt"
     },
     {
-      "id": 4463,
       "label": "text_go",
       "translation": "Envie-me um texto com a palavra GO quando estiver pronto.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:07:12Z",
-      "updated_at": "2020-03-22T20:07:12Z",
       "language": "pt"
     },
     {
-      "id": 4464,
       "label": "drill_self_assess_1",
       "translation": "Ok! Aqui vamos nós! Vamos começar primeiro aprendendo um pouco sobre você.  ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:10:23Z",
-      "updated_at": "2020-03-22T20:10:23Z",
       "language": "pt"
     },
     {
-      "id": 4467,
       "label": "drill_self_assess_3",
       "translation": "(Sua resposta será mantida em sigilo.)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:17:08Z",
-      "updated_at": "2020-03-24T06:59:44Z",
       "language": "pt"
     },
     {
-      "id": 4469,
       "label": "covid_1_fact_1",
       "translation": "FATO: COVID-19 não é uma bactéria. É uma doença viral. Se você ouvir alguém dizer \"coronavírus\" ou \"novo coronavírus\", eles estão falando sobre a mesma doença.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:26:16Z",
-      "updated_at": "2020-03-22T20:26:16Z",
       "language": "pt"
     },
     {
-      "id": 4474,
       "label": "covid_1_practice_4",
       "translation": "Responda a pergunta.\n\nQuais são os sintomas mais comuns do COVID-19?\n\na) Dor de estômago, náusea, diarréia\nb) Febre, tosse, dificuldade em respirar\nc) Erupção cutânea com comichão\nd) Visão turva",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:40:07Z",
-      "updated_at": "2020-03-23T02:01:11Z",
       "language": "pt"
     },
     {
-      "id": 4475,
       "label": "covid_1_fact_4",
       "translation": "FATO: Se você ou alguém próximo a você tiver dificuldade em respirar, dor no peito, confusão ou lábios azuis, procure atendimento médico imediatamente.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:42:50Z",
-      "updated_at": "2020-03-22T20:42:50Z",
       "language": "pt"
     },
     {
-      "id": 4473,
       "label": "covid_1_fact_3",
       "translation": "FATO: É possível que o COVID-19 seja transmitido por pessoas que não mostram sintomas da doença. \nMantenha distância de outras pessoas e pratique sempre uma boa higiene para estar seguro.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:32:54Z",
-      "updated_at": "2020-03-22T20:37:43Z",
       "language": "pt"
     },
     {
-      "id": 4476,
       "label": "covid_1_practice_5",
       "translation": "Se você acha que pode ter sintomas do COVID-19, deveria [---]. \n\na) fique em casa, exceto pelos cuidados médicos\nb) não use o transporte público\nc) ligue para seu médico antes de visitar \nd) Todas as opções acima. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:43:25Z",
-      "updated_at": "2020-03-23T02:07:13Z",
       "language": "pt"
     },
     {
-      "id": 4468,
       "label": "covid_1_practice_1",
       "translation": "Verdadeiro ou falso?\n\nCOVID-19 é uma bactéria.\n\na) verdadeiro\nb) falso\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:21:21Z",
-      "updated_at": "2020-03-24T06:21:31Z",
       "language": "pt"
     },
     {
-      "id": 4477,
       "label": "covid_1_fact_5",
       "translation": "LES FAITS: Si vous n’avez que de très légers symptômes, isolez-vous pour éviter de contaminer d’autres personnes. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:47:15Z",
-      "updated_at": "2020-03-22T20:47:15Z",
       "language": "fr"
     },
     {
-      "id": 4478,
       "label": "covid_1_fact_5",
       "translation": "FATO: Se você tiver apenas sintomas leves, se isole para controlar a propagação do COVID-19.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:47:39Z",
-      "updated_at": "2020-03-22T20:47:39Z",
       "language": "pt"
     },
     {
-      "id": 4479,
       "label": "covid_1_fact_5",
       "translation": "如果你有轻微症状，请自主居家隔离，帮助防止病毒传播",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:47:51Z",
-      "updated_at": "2020-03-22T20:47:51Z",
       "language": "zh"
     },
     {
-      "id": 4466,
       "label": "likert_1_10_knowledge",
       "translation": "(1 = Não sei nada, 10 = Sou especialista e ensino outras pessoas)",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:13:30Z",
-      "updated_at": "2020-03-22T20:54:32Z",
       "language": "pt"
     },
     {
-      "id": 4445,
       "label": "covid_2_title",
       "translation": "COVID-19 Prévention",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:50:32Z",
-      "updated_at": "2020-03-24T00:36:49Z",
       "language": "fr"
     },
     {
-      "id": 4441,
       "label": "covid_1_title",
       "translation": "Ce qu’il faut savoir sur le COVID-19",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:46:55Z",
-      "updated_at": "2020-03-24T01:35:18Z",
       "language": "fr"
     },
     {
-      "id": 4439,
       "label": "covid_1_title",
       "translation": "COVID-19 Basics",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:43:47Z",
-      "updated_at": "2020-03-24T16:40:22Z",
       "language": "en"
     },
     {
-      "id": 4622,
-      "label": "yes",
-      "translation": "verdadeiro",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:49:00Z",
-      "updated_at": "2020-03-23T20:49:00Z",
-      "language": "pt"
-    },
-    {
-      "id": 4472,
       "label": "covid_1_practice_3",
       "translation": "Responda a pergunta. \n\nComo o COVID-19 é transmitido de pessoa para pessoa?\n\na) Contato próximo com uma pessoa infectada\nb) Respiratório cai no ar quando uma pessoa doente tosse ou espirra\nc) Ao tocar uma superfície com o vírus e depois tocar no rosto\nd) Todas acima\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:31:51Z",
-      "updated_at": "2020-03-23T01:55:09Z",
       "language": "pt"
     },
     {
-      "id": 4625,
-      "label": "hands",
-      "translation": "手部接触传播",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:52:25Z",
-      "updated_at": "2020-03-23T20:52:25Z",
-      "language": "zh"
-    },
-    {
-      "id": 4440,
       "label": "covid_1_title",
       "translation": "Los básicos de COVID-19",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T23:46:25Z",
-      "updated_at": "2020-03-24T16:40:38Z",
       "language": "es"
     },
     {
-      "id": 4481,
       "label": "covid_2_title",
       "translation": "Covid-19 Prevenção",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:51:57Z",
-      "updated_at": "2020-03-24T00:36:56Z",
       "language": "pt"
     },
     {
-      "id": 4480,
       "label": "drill_complete_congrats",
       "translation": "Parabéns {{name}}! Você concluiu seu treinamento hoje. \n\nInformaremos {{company}} que você terminou.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:49:45Z",
-      "updated_at": "2020-03-24T02:26:23Z",
       "language": "pt"
     },
     {
-      "id": 4465,
       "label": "drill_self_assess_2",
       "translation": "Em uma escala de 1 a 10, como você classificaria seu conhecimento atual do tópico de hoje: ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:10:57Z",
-      "updated_at": "2020-03-22T20:53:25Z",
       "language": "pt"
     },
     {
-      "id": 4482,
       "label": "drill_practice_caps",
       "translation": "EXERCÍCIO",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T20:55:20Z",
-      "updated_at": "2020-03-22T20:55:20Z",
       "language": "pt"
     },
     {
-      "id": 4293,
       "label": "covid_prev_practice_1",
       "translation": "Répondez à cette question. \n\nQuel est le meilleur moyen de ne pas attraper le COVID-19?\n\na) Se faire vacciner chez son médecin\nb) Éviter d’être exposé(e) au virus\nc) Boire beaucoup d’eau\nd) Manger des légumes\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:13:37Z",
-      "updated_at": "2020-03-22T21:12:18Z",
       "language": "fr"
     },
     {
-      "id": 4483,
       "label": "covid_prev_practice_1",
       "translation": "Responda a pergunta\n\nQual é a melhor maneira de evitar adoecer com COVID-19?\n\na) Receba a vacina de seu médico\nb) Evite se expor ao vírus\nc) Beba bastante água\nd) Coma vegetais folhosos ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:11:57Z",
-      "updated_at": "2020-03-22T21:12:44Z",
       "language": "pt"
     },
     {
-      "id": 4484,
       "label": "covid_prev_fact_1",
       "translation": "FATO: Atualmente, não existe vacina contra o vírus, e é por isso que o distanciamento social e a boa higiene das mãos são tão cruciais para evitar o adoecimento.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:14:02Z",
-      "updated_at": "2020-03-22T21:14:02Z",
       "language": "pt"
     },
     {
-      "id": 4485,
       "label": "covid_prev_practice_2",
       "translation": "Qual é a melhor maneira de evitar a exposição ao COVID-19?\n\na) Manter distância social \nb) Lavar as mãos com frequência\nc) Evite tocar seus olhos, nariz e boca\nd) Alla acima!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:16:59Z",
-      "updated_at": "2020-03-22T21:16:59Z",
       "language": "pt"
     },
     {
-      "id": 4486,
       "label": "covid_prev_fact_2",
       "translation": "FATO: COVID-19 é transmitido principalmente pelo ar e pelo sistema respiratório. É importante manter distância dos outros, lavar as mãos e não tocar no rosto.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:17:50Z",
-      "updated_at": "2020-03-22T21:17:50Z",
       "language": "pt"
     },
     {
-      "id": 4487,
       "label": "covid_prev_practice_3",
       "translation": "Quando os sintomas geralmente aparecem COVID-19?\n\na) Imediatamente após a exposição\nb) 12 horas após a exposição,\nc) 2-14 dias após a exposição",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:19:14Z",
-      "updated_at": "2020-03-22T21:19:14Z",
       "language": "pt"
     },
     {
-      "id": 4488,
       "label": "covid_prev_fact_3",
       "translation": "FATO: COVID-19 pode ser transmitido por pessoas que não apresentam sintomas da doença. Mantenha uma distância social para evitar ser infectado ou infectar outras pessoas. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:21:57Z",
-      "updated_at": "2020-03-22T21:21:57Z",
       "language": "pt"
     },
     {
-      "id": 4489,
       "label": "covid_prev_practice_4",
       "translation": "Quando deve usar uma máscara?\n\na) se você tossir ou espirrar\nb) se apresentar sintomas de COVID-19\nc) se estiver cuidando de alguém com suspeita de COVID-19\nd) todos acima",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:23:29Z",
-      "updated_at": "2020-03-22T21:23:29Z",
       "language": "pt"
     },
     {
-      "id": 4510,
       "label": "drill_how_to_fact_5",
       "translation": "FATO: Germes podem ser transferidos mais facilmente em mãos molhadas.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:41:29Z",
-      "updated_at": "2020-03-24T06:51:49Z",
       "language": "pt"
     },
     {
-      "id": 4492,
       "label": "covid_3_title",
       "translation": "How to wash your hands",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:46:47Z",
-      "updated_at": "2020-03-22T21:46:47Z",
       "language": "en"
     },
     {
-      "id": 4493,
       "label": "covid_3_title",
       "translation": "Como lavar as mãos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:55:16Z",
-      "updated_at": "2020-03-22T21:55:16Z",
       "language": "pt"
     },
     {
-      "id": 4494,
       "label": "covid_3_title",
       "translation": "Cómo lavarse las manos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:55:25Z",
-      "updated_at": "2020-03-22T21:55:25Z",
       "language": "es"
     },
     {
-      "id": 4495,
       "label": "covid_3_title",
       "translation": "Comment se laver les mains",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:56:32Z",
-      "updated_at": "2020-03-22T21:56:32Z",
       "language": "fr"
     },
     {
-      "id": 4496,
       "label": "covid_3_title",
       "translation": "如何洗手\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:56:50Z",
-      "updated_at": "2020-03-22T21:56:50Z",
       "language": "zh"
     },
     {
-      "id": 4490,
       "label": "covid_prev_fact_4",
       "translation": "FATO: Se você estiver saudável, você só precisará usar uma máscara se estiver cuidando de alguém com COVID-19.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:24:32Z",
-      "updated_at": "2020-03-24T03:50:15Z",
       "language": "pt"
     },
     {
-      "id": 4499,
       "label": "drill_how_to_fact_2",
       "translation": "FATO: A água quente é excelente para remover o óleo das suas mãos! Quando se trata de germes, água quente e fria são igualmente eficazes. Lavar bem as mãos é sobre a quantidade de sabão usada e a quantidade de tempo que você lava as mãos.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:14:22Z",
-      "updated_at": "2020-03-22T22:14:22Z",
       "language": "pt"
     },
     {
-      "id": 4616,
-      "label": "percentage_alcohol_based",
-      "translation": "酒精含量在 60% - 90%之间",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:39:45Z",
-      "updated_at": "2020-03-23T20:39:45Z",
-      "language": "zh"
-    },
-    {
-      "id": 4501,
       "label": "drill_how_to_fact_3",
       "translation": "FATO: Bombeie sabão suficiente para cobrir as mãos. Isso significa 2 bombas ou mais! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:16:32Z",
-      "updated_at": "2020-03-22T22:16:32Z",
       "language": "pt"
     },
     {
-      "id": 4502,
       "label": "drill_how_to_practice_3",
       "translation": "Escolha a melhor opção para preencher o espaço em branco. \n\nLave as palmas das mãos e o topo das mãos. Não esqueça de esfregar entre [---].\n\na) dedos\nb) dedos dos pés\nc) dedos e sob as unhas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:18:04Z",
-      "updated_at": "2020-03-22T22:18:04Z",
       "language": "pt"
     },
     {
-      "id": 4503,
       "label": "drill_how_to_practice_3",
       "translation": "洗手时，请务必洗手掌和手背。 也不要忘记清洗:\n\na）手指\nb）脚趾头\nc）手指和指甲下",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:18:52Z",
-      "updated_at": "2020-03-22T22:18:52Z",
       "language": "zh"
     },
     {
-      "id": 3268,
       "label": "drill_how_to_practice_3",
       "translation": "Choose the best option to fill in the space. \n\nWash the palms and tops of your hands. Don't forget to scrub between [---].\n\na) your fingers \nb) your toes\nc) your fingers and under your fingernails ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:41:21Z",
-      "updated_at": "2020-03-22T22:19:02Z",
       "language": "en"
     },
     {
-      "id": 4504,
       "label": "drill_how_to_fact_4",
       "translation": "FATO: As bactérias têm maior probabilidade de se esconder sob as unhas.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:21:11Z",
-      "updated_at": "2020-03-22T22:21:11Z",
       "language": "pt"
     },
     {
-      "id": 4505,
       "label": "drill_how_to_fact_4",
       "translation": "细菌最有可能藏在指甲下。\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:21:38Z",
-      "updated_at": "2020-03-22T22:21:42Z",
       "language": "zh"
     },
     {
-      "id": 4506,
       "label": "drill_how_to_practice_4",
       "translation": "Escolha a melhor opção para preencher o espaço em branco. \n\nEsfregue bem as mãos com sabão [---].\n\na) por 10 segundos\nb) por 20 segundos\nc) por 60 segundos\nd) se você quiser\ne) enquanto come",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:23:23Z",
-      "updated_at": "2020-03-22T22:23:23Z",
       "language": "pt"
     },
     {
-      "id": 4507,
       "label": "drill_how_to_practice_4",
       "translation": "你应该用肥皂大力揉搓双手多长时间?\n\na）大约十秒\nb）大约二十秒\nc）大约六十秒\nd）多久都没关系",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:23:42Z",
-      "updated_at": "2020-03-22T22:23:42Z",
       "language": "zh"
     },
     {
-      "id": 3267,
       "label": "drill_how_to_practice_4",
       "translation": "Choisissez la meilleure option pour compléter la phrase. \n\nFrottez-vous vigoureusement les mains avec du savon [---]\n\na) Pendant 10 secondes\nb) Pendant 20 secondes\nc) Pendant 60 secondes\nd) Si vous avez envie\ne) Pendant que vous mangez",
-      "translation_type": "lesson",
-      "created_at": "2020-03-09T04:39:54Z",
-      "updated_at": "2020-03-22T22:24:38Z",
       "language": "fr"
     },
     {
-      "id": 4508,
       "label": "almost_done",
       "translation": "快完成了",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:39:56Z",
-      "updated_at": "2020-03-22T22:39:56Z",
       "language": "zh"
     },
     {
-      "id": 4509,
       "label": "drill_how_to_fact_5",
       "translation": "潮湿的手更容易传播细菌",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:41:18Z",
-      "updated_at": "2020-03-22T22:41:18Z",
       "language": "zh"
     },
     {
-      "id": 4512,
       "label": "drill_how_to_practice_5",
       "translation": "弄干手的最安全的方法是什么？\n\na）用毛巾擦干\nb）甩干\nc）晾干\nd）在衣服上擦干\ne）用纸巾、厨房纸擦干或者用干手机烘干",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:47:23Z",
-      "updated_at": "2020-03-22T22:47:23Z",
       "language": "zh"
     },
     {
-      "id": 4513,
       "label": "covid_4_title",
       "translation": "Melhores práticas com desinfetantes para as mãos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:10:18Z",
-      "updated_at": "2020-03-22T23:10:18Z",
       "language": "pt"
     },
     {
-      "id": 4515,
       "label": "hand_sani_fact_1",
       "translation": "FATO: Os desinfetantes para as mãos podem reduzir rapidamente os germes em suas mãos, mas não matam todos os tipos de germes. Sabão e água são mais eficazes que os desinfetantes para as mãos. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:13:10Z",
-      "updated_at": "2020-03-22T23:13:10Z",
       "language": "pt"
     },
     {
-      "id": 4514,
       "label": "hand_sani_practice_1",
       "translation": "Desinfetantes para as mãos matam todos os tipos de germes. \n\na) verdadeiro\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:11:56Z",
-      "updated_at": "2020-03-24T00:04:06Z",
       "language": "pt"
     },
     {
-      "id": 4497,
-      "label": "drill_intro_3",
-      "translation": "Por favor, envie-me a palavra GO para começar!",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:02:13Z",
-      "updated_at": "2020-03-29T23:43:56Z",
-      "language": "pt"
-    },
-    {
-      "id": 4623,
-      "label": "yes",
-      "translation": "Vrai",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:49:07Z",
-      "updated_at": "2020-03-23T20:49:07Z",
-      "language": "fr"
-    },
-    {
-      "id": 4491,
       "label": "covid_prev_practice_5",
       "translation": "As máscaras só são eficazes quando você também lava as mãos regularmente.\n\na) verdadeiro\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T21:25:12Z",
-      "updated_at": "2020-03-24T03:52:05Z",
       "language": "pt"
     },
     {
-      "id": 4498,
       "label": "drill_how_to_practice_1",
       "translation": "Você só deve lavar as mãos com água morna. \n\na) verdadeiro\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:09:32Z",
-      "updated_at": "2020-03-24T23:34:46Z",
       "language": "pt"
     },
     {
-      "id": 4516,
       "label": "hand_sani_practice_2",
       "translation": "Escolha a melhor opção para preencher o espaço em branco. \n\nSe sabão e água não estiverem disponíveis, use desinfetante para as mãos [---]. \n \na) à base de água sanitária\nb) à base de sabão\nc) à base de álcool",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:15:39Z",
-      "updated_at": "2020-03-22T23:15:51Z",
       "language": "pt"
     },
     {
-      "id": 4517,
       "label": "hand_sani_fact_2",
       "translation": "FATO: Desinfetantes à base de álcool, que não necessitam de água, são uma alternativa aceitável, quando o sabão e água disponível não estão disponíveis.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:17:00Z",
-      "updated_at": "2020-03-22T23:17:00Z",
       "language": "pt"
     },
     {
-      "id": 4518,
       "label": "hand_sani_practice_3",
       "translation": "Responda a pergunta.\n\nAo usar um desinfetante para as mãos à base de álcool, verifique se ele contém [---] álcool.\n \na) pelo menos 30%,\nb) pelo menos 60%, \nc) apenas 90% ou mais",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:18:14Z",
-      "updated_at": "2020-03-22T23:19:01Z",
       "language": "pt"
     },
     {
-      "id": 4519,
       "label": "hand_sani_fact_3",
       "translation": "FATO: Os desinfetantes com uma concentração de álcool entre 60-95% são mais eficazes contra os germes do que aqueles com uma menor concentração de álcool. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:20:07Z",
-      "updated_at": "2020-03-22T23:20:07Z",
       "language": "pt"
     },
     {
-      "id": 4520,
       "label": "hand_sani_practice_4",
       "translation": "Para usar o desinfetante para as mãos corretamente, esfregue-o nas superfícies das mãos até que estejam secas.\n\na) verdadeiro\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:21:42Z",
-      "updated_at": "2020-03-22T23:21:57Z",
       "language": "pt"
     },
     {
-      "id": 4521,
       "label": "hand_sani_fact_4",
       "translation": "FATO: Esfregue o desinfetante nas mãos até que estejam secas. Lembre-se de que isso reduzirá apenas o crescimento de germes; não os matará completamente.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:33:28Z",
-      "updated_at": "2020-03-22T23:33:28Z",
       "language": "pt"
     },
     {
-      "id": 4522,
       "label": "hand_sani_practice_5",
       "translation": "Desinfetantes perfumados são aceitáveis ​​desde [---].\n\na) use ingredientes orgânicos que\nb) contenham anticorpos\nc) cheiram bem a\nd) 60-90% de álcool com base em \ne) todos acima",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:37:07Z",
-      "updated_at": "2020-03-22T23:37:07Z",
       "language": "pt"
     },
     {
-      "id": 4523,
       "label": "covid_5_title",
       "translation": "Como desinfetar seu telefone",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:40:23Z",
-      "updated_at": "2020-03-22T23:40:23Z",
       "language": "pt"
     },
     {
-      "id": 4524,
       "label": "disinfect_phone_practice_1",
       "translation": "80 por cento de todas as infecções são transmitidas através de [---]\n\na) mãos\nb) de tosse\nc) espirros",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:43:41Z",
-      "updated_at": "2020-03-24T00:10:05Z",
       "language": "pt"
     },
     {
-      "id": 4525,
       "label": "disinfect_phone_fact_1",
       "translation": "FATO: Nossos smartphones se tornaram uma extensão de nossas mãos, por isso é importante desinfetar.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:44:25Z",
-      "updated_at": "2020-03-22T23:44:25Z",
       "language": "pt"
     },
     {
-      "id": 4541,
       "label": "high_contact_practice_1",
       "translation": "COVID19 não pode sobreviver em superfícies de materiais.\n\na) verdadeiro\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T00:58:15Z",
-      "updated_at": "2020-03-23T00:58:15Z",
       "language": "pt"
     },
     {
-      "id": 4527,
       "label": "disinfect_phone_fact_2",
       "translation": "FATO: Por esse motivo, os telefones celulares são um dos objetos mais sujos com os quais interagimos diariamente. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:46:58Z",
-      "updated_at": "2020-03-22T23:47:18Z",
       "language": "pt"
     },
     {
-      "id": 4528,
       "label": "disinfect_phone_practice_3",
       "translation": "É seguro usar toalhetes higiênicos no seu telefone?\n\na) sim\nb) não",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:50:22Z",
-      "updated_at": "2020-03-22T23:50:22Z",
       "language": "pt"
     },
     {
-      "id": 4530,
       "label": "disinfect_phone_practice_4",
       "translation": "Escolha a melhor opção para preencher o espaço em branco. \n\nLimpe seu telefone enquanto estiver [---]\n\na) desligado \nb) desconectado\nc) desligado e desconectado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:51:44Z",
-      "updated_at": "2020-03-22T23:51:44Z",
       "language": "pt"
     },
     {
-      "id": 4531,
       "label": "disinfect_phone_fact_4",
       "translation": "FATO: Desinfetante para as mãos, pode passar facilmente por pequenas rachaduras e entrar no telefone. Pode causar danos permanentes. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:53:26Z",
-      "updated_at": "2020-03-22T23:53:26Z",
       "language": "pt"
     },
     {
-      "id": 4532,
       "label": "disinfect_phone_practice_5",
       "translation": "A melhor maneira de usar o telefone para evitar a propagação de germes é [---]\n\na) evitar pressionar o telefone contra o rosto\nb) ouvido use\nc) viva-voz quando apropriado\nd) todos acima",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:57:20Z",
-      "updated_at": "2020-03-22T23:57:20Z",
       "language": "pt"
     },
     {
-      "id": 4533,
       "label": "disinfect_phone_fact_5",
       "translation": "FATO: Os celulares contêm germes sua superfície por mais de 3 dias. Toda vez que você toca no telefone, corre o risco de ficar doente. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:58:36Z",
-      "updated_at": "2020-03-22T23:58:36Z",
       "language": "pt"
     },
     {
-      "id": 4534,
       "label": "covid_6_title",
       "translation": "When to wash your hands",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:59:32Z",
-      "updated_at": "2020-03-22T23:59:43Z",
       "language": "en"
     },
     {
-      "id": 4535,
       "label": "covid_6_title",
       "translation": "Quando lavar as mãos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:59:59Z",
-      "updated_at": "2020-03-22T23:59:59Z",
       "language": "pt"
     },
     {
-      "id": 4536,
       "label": "covid_6_title",
       "translation": "Quand faut-il se laver les mains",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T00:00:16Z",
-      "updated_at": "2020-03-23T00:00:16Z",
       "language": "fr"
     },
     {
-      "id": 4537,
       "label": "covid_6_title",
       "translation": "Cuándo lavarse las manos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T00:00:28Z",
-      "updated_at": "2020-03-23T00:00:28Z",
       "language": "es"
     },
     {
-      "id": 4538,
       "label": "covid_6_title",
       "translation": "什么时候需要洗手",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T00:00:39Z",
-      "updated_at": "2020-03-23T00:00:39Z",
       "language": "zh"
     },
     {
-      "id": 4539,
       "label": "drill_2_when_to_intro",
       "translation": "我们的培训将围绕防止病菌传播的主题来展开。",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T00:10:17Z",
-      "updated_at": "2020-03-23T00:10:17Z",
       "language": "zh"
     },
     {
-      "id": 4094,
       "label": "drill_when_to_practice_2",
       "translation": "Choisissez la bonne réponse pour compléter la phrase. \n\nLes gants en latex remplacent [---] le lavage des mains. \n\na) Toujours\nb) De temps en temps\nc) Jamais",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:05:39Z",
-      "updated_at": "2020-03-23T00:42:33Z",
       "language": "fr"
     },
     {
-      "id": 4540,
       "label": "covid_7_title",
       "translation": "Desinfecção de superfícies de alto contato",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T00:52:57Z",
-      "updated_at": "2020-03-23T00:52:57Z",
       "language": "pt"
     },
     {
-      "id": 4406,
       "label": "high_contact_practice_1",
       "translation": "COVID19 no puede sobrevivir en superficies de materiales.\n\na) verdadero\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:21:02Z",
-      "updated_at": "2020-03-23T00:59:22Z",
       "language": "es"
     },
     {
-      "id": 4409,
       "label": "high_contact_fact_1",
       "translation": "LES FAITS: Des premiers résultats suggèrent que le virus du COVID-19 peut rester longtemps sur les poignées de porte, le plastique, les plans de travail et autres surfaces dures. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:22:11Z",
-      "updated_at": "2020-03-23T01:00:59Z",
       "language": "fr"
     },
     {
-      "id": 4542,
       "label": "high_contact_fact_1",
       "translation": "FATO: Os primeiros resultados sugerem que o vírus COVID-19 pode durar em portas, bancadas plásticas laminadas ou revestidas e outras superfícies duras.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T00:59:57Z",
-      "updated_at": "2020-03-23T01:01:04Z",
       "language": "pt"
     },
     {
-      "id": 4543,
       "label": "high_contact_practice_2",
       "translation": "Escolha a melhor opção para preencher o espaço em branco. \n\nMesas, maçanetas, interruptores de luz, bancadas, alças, mesas, telefones, teclados, banheiros, torneiras, pias são [---]\n\na) superfícies de baixo contato\nb) superfícies de alto contato\nc) nunca sujas\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T01:03:20Z",
-      "updated_at": "2020-03-23T01:03:20Z",
       "language": "pt"
     },
     {
-      "id": 4544,
       "label": "high_contact_fact_2",
       "translation": "FATO: As evidências atuais sugerem que o COVID-19 pode permanecer em superfícies entre horas e dias. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T01:03:49Z",
-      "updated_at": "2020-03-23T01:03:49Z",
       "language": "pt"
     },
     {
-      "id": 4545,
       "label": "high_contact_practice_3",
       "translation": "Escolha a melhor opção para preencher o espaço em branco.\n\nCOVID-19 pode sobreviver à caixa de papelão por [---].\n\na) até 24 horas\nb) 2-3 dias\nc) 1 semana",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T01:05:12Z",
-      "updated_at": "2020-03-23T01:06:40Z",
       "language": "pt"
     },
     {
-      "id": 4546,
       "label": "high_contact_fact_3",
       "translation": "FATO: Depois de tocar na caixa de remessa, você deve sempre lavar as mãos. Luvas não impedirão o contágio.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T01:07:22Z",
-      "updated_at": "2020-03-23T01:07:22Z",
       "language": "pt"
     },
     {
-      "id": 4547,
       "label": "high_contact_practice_4",
       "translation": "COVID-19 pode sobreviver em superfícies de plástico e aço inoxidável por [---].\n\na) até 24 horas\nb) 2-3 dias\nc) 1 semana",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T01:08:33Z",
-      "updated_at": "2020-03-23T01:08:33Z",
       "language": "pt"
     },
     {
-      "id": 4526,
       "label": "disinfect_phone_practice_2",
       "translation": "A tela média do smartphone tem mais de três vezes a bagunça de uma sanita. \n\na) verdadeiro\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:46:32Z",
-      "updated_at": "2020-03-24T00:11:02Z",
       "language": "pt"
     },
     {
-      "id": 4390,
       "label": "disinfect_phone_practice_4",
       "translation": "Elija la mejor opción para llenar el blanco.\n\nLimpie su teléfono mientras está [---]\n\na) apagado \nb) desconectado\nc) apagado y desconectado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:11:18Z",
-      "updated_at": "2020-03-24T01:14:36Z",
       "language": "es"
     },
     {
-      "id": 4529,
       "label": "disinfect_phone_fact_3",
       "translation": "FATO: Muitos lenços desinfetantes podem ser usados ​​em smartphones, tablets e controles remotos. Apenas verifique o rótulo do desinfetante primeiro para confirmar se é seguro para esse uso! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T23:51:20Z",
-      "updated_at": "2020-03-24T06:59:14Z",
       "language": "pt"
     },
     {
-      "id": 4548,
       "label": "high_contact_fact_4",
       "translation": "FATO: As roupas e outras superfícies macias são mais difíceis de desinfetar, ainda não se sabe quanto tempo o vírus pode sobreviver nesses materiais. Não sacuda roupas sujas. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T01:09:06Z",
-      "updated_at": "2020-03-23T01:09:06Z",
       "language": "pt"
     },
     {
-      "id": 4459,
       "label": "stop_covid_thanks",
       "translation": "Obrigado por dedicar seu tempo a este treinamento. Ao concluir essas atividades diariamente, você ajudará a impedir a propagação desse vírus.\n\nJuntos, podemos parar o COVID-19.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T19:08:16Z",
-      "updated_at": "2020-03-23T01:13:47Z",
       "language": "pt"
     },
     {
-      "id": 4550,
-      "label": "avoid_being_exposed_to_the_virus",
-      "translation": "Avoid being exposed to the virus",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T18:34:50Z",
-      "updated_at": "2020-03-23T18:36:27Z",
-      "language": "en"
-    },
-    {
-      "id": 4551,
-      "label": "true",
-      "translation": "True",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:12:53Z",
-      "updated_at": "2020-03-23T19:13:26Z",
-      "language": "en"
-    },
-    {
-      "id": 4552,
-      "label": "true",
-      "translation": "Verdadero",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:15:01Z",
-      "updated_at": "2020-03-23T19:15:01Z",
-      "language": "es"
-    },
-    {
-      "id": 4553,
-      "label": "true",
-      "translation": "Vrai",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:15:13Z",
-      "updated_at": "2020-03-23T19:15:13Z",
-      "language": "fr"
-    },
-    {
-      "id": 4554,
-      "label": "true",
-      "translation": "Verdadeiro",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:15:23Z",
-      "updated_at": "2020-03-23T19:15:23Z",
-      "language": "pt"
-    },
-    {
-      "id": 4555,
-      "label": "true",
-      "translation": "正确",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:15:54Z",
-      "updated_at": "2020-03-23T19:15:54Z",
-      "language": "zh"
-    },
-    {
-      "id": 4556,
-      "label": "false",
-      "translation": "False",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:17:06Z",
-      "updated_at": "2020-03-23T19:17:19Z",
-      "language": "en"
-    },
-    {
-      "id": 4557,
-      "label": "false",
-      "translation": "Falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:17:28Z",
-      "updated_at": "2020-03-23T19:17:28Z",
-      "language": "es"
-    },
-    {
-      "id": 4558,
-      "label": "false",
-      "translation": "Falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:17:35Z",
-      "updated_at": "2020-03-23T19:17:35Z",
-      "language": "pt"
-    },
-    {
-      "id": 4559,
-      "label": "false",
-      "translation": "Faux",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:17:43Z",
-      "updated_at": "2020-03-23T19:17:43Z",
-      "language": "fr"
-    },
-    {
-      "id": 4560,
-      "label": "false",
-      "translation": "错误",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:17:57Z",
-      "updated_at": "2020-03-23T19:17:57Z",
-      "language": "zh"
-    },
-    {
-      "id": 4561,
-      "label": "more_contagious_than",
-      "translation": "more contagious than",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:23:10Z",
-      "updated_at": "2020-03-23T19:23:10Z",
-      "language": "en"
-    },
-    {
-      "id": 4562,
-      "label": "more_contagious_than",
-      "translation": "比流感强",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:23:21Z",
-      "updated_at": "2020-03-23T19:23:21Z",
-      "language": "zh"
-    },
-    {
-      "id": 4563,
-      "label": "more_contagious_than",
-      "translation": "mais contagioso que",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:23:28Z",
-      "updated_at": "2020-03-23T19:23:28Z",
-      "language": "pt"
-    },
-    {
-      "id": 4564,
-      "label": "more_contagious_than",
-      "translation": "plus contagieux",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:23:36Z",
-      "updated_at": "2020-03-23T19:23:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 4565,
-      "label": "more_contagious_than",
-      "translation": "más contagioso que",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:23:46Z",
-      "updated_at": "2020-03-23T19:23:46Z",
-      "language": "es"
-    },
-    {
-      "id": 4566,
-      "label": "all_of_the_above",
-      "translation": "All of the above",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:26:11Z",
-      "updated_at": "2020-03-23T19:26:23Z",
-      "language": "en"
-    },
-    {
-      "id": 4567,
-      "label": "all_of_the_above",
-      "translation": "以上全部方式",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:26:31Z",
-      "updated_at": "2020-03-23T19:26:31Z",
-      "language": "zh"
-    },
-    {
-      "id": 4568,
-      "label": "all_of_the_above",
-      "translation": "Todas acima",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:26:38Z",
-      "updated_at": "2020-03-23T19:26:38Z",
-      "language": "pt"
-    },
-    {
-      "id": 4569,
-      "label": "all_of_the_above",
-      "translation": "Toutes les options ci-dessus",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:26:47Z",
-      "updated_at": "2020-03-23T19:26:47Z",
-      "language": "fr"
-    },
-    {
-      "id": 4570,
-      "label": "all_of_the_above",
-      "translation": "Todas las anteriores",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:26:55Z",
-      "updated_at": "2020-03-23T19:26:55Z",
-      "language": "es"
-    },
-    {
-      "id": 4572,
-      "label": "fever_cough_shortness_of_breath",
-      "translation": "干咳、发烧、胸闷气短",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:29:31Z",
-      "updated_at": "2020-03-23T19:29:31Z",
-      "language": "zh"
-    },
-    {
-      "id": 4571,
-      "label": "fever_cough_shortness_of_breath",
-      "translation": "Fever, cough, shortness of breath",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:29:21Z",
-      "updated_at": "2020-03-23T19:29:36Z",
-      "language": "en"
-    },
-    {
-      "id": 4573,
-      "label": "fever_cough_shortness_of_breath",
-      "translation": "Fiebre, tos, dificultad al respirar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:29:43Z",
-      "updated_at": "2020-03-23T19:29:43Z",
-      "language": "es"
-    },
-    {
-      "id": 4574,
-      "label": "fever_cough_shortness_of_breath",
-      "translation": "Fièvre, toux, souffle court",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:29:51Z",
-      "updated_at": "2020-03-23T19:29:51Z",
-      "language": "fr"
-    },
-    {
-      "id": 4575,
-      "label": "fever_cough_shortness_of_breath",
-      "translation": "Febre, tosse, dificuldade em respirar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:30:01Z",
-      "updated_at": "2020-03-23T19:30:01Z",
-      "language": "pt"
-    },
-    {
-      "id": 4576,
-      "label": "avoid_being_exposed_to_the_virus",
-      "translation": "尽量避免和病毒的接触",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:33:22Z",
-      "updated_at": "2020-03-23T19:33:22Z",
-      "language": "zh"
-    },
-    {
-      "id": 4577,
-      "label": "avoid_being_exposed_to_the_virus",
-      "translation": "Evite se expor ao vírus",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:33:27Z",
-      "updated_at": "2020-03-23T19:33:27Z",
-      "language": "pt"
-    },
-    {
-      "id": 4578,
-      "label": "avoid_being_exposed_to_the_virus",
-      "translation": "Éviter d’être exposé(e) au virus",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:33:36Z",
-      "updated_at": "2020-03-23T19:33:36Z",
-      "language": "fr"
-    },
-    {
-      "id": 4579,
-      "label": "avoid_being_exposed_to_the_virus",
-      "translation": "Evite exponerse al virus",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:33:53Z",
-      "updated_at": "2020-03-23T19:33:53Z",
-      "language": "es"
-    },
-    {
-      "id": 4580,
-      "label": "days_after_exposure",
-      "translation": "2-14 days after exposure",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:38:47Z",
-      "updated_at": "2020-03-23T19:38:58Z",
-      "language": "en"
-    },
-    {
-      "id": 4581,
-      "label": "days_after_exposure",
-      "translation": "2-14 dias após a exposição\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:39:36Z",
-      "updated_at": "2020-03-23T19:39:36Z",
-      "language": "pt"
-    },
-    {
-      "id": 4582,
-      "label": "days_after_exposure",
-      "translation": "2 - 14 天",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:40:23Z",
-      "updated_at": "2020-03-23T19:40:23Z",
-      "language": "zh"
-    },
-    {
-      "id": 4583,
-      "label": "days_after_exposure",
-      "translation": "2-14 días después de exposición",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:40:34Z",
-      "updated_at": "2020-03-23T19:40:34Z",
-      "language": "es"
-    },
-    {
-      "id": 4584,
-      "label": "days_after_exposure",
-      "translation": "2 à 14 jours après y avoir été exposé",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T19:40:47Z",
-      "updated_at": "2020-03-23T19:40:47Z",
-      "language": "fr"
-    },
-    {
-      "id": 4586,
-      "label": "soap_pumps_to_wash_hands",
-      "translation": "按两三次",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:03:36Z",
-      "updated_at": "2020-03-23T20:03:36Z",
-      "language": "zh"
-    },
-    {
-      "id": 4587,
-      "label": "soap_pumps_to_wash_hands",
-      "translation": "2-3 bombas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:03:46Z",
-      "updated_at": "2020-03-23T20:03:46Z",
-      "language": "pt"
-    },
-    {
-      "id": 4588,
-      "label": "soap_pumps_to_wash_hands",
-      "translation": "2-3 gouttes",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:03:54Z",
-      "updated_at": "2020-03-23T20:03:54Z",
-      "language": "fr"
-    },
-    {
-      "id": 4589,
-      "label": "soap_pumps_to_wash_hands",
-      "translation": "2-3 bombeos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:04:05Z",
-      "updated_at": "2020-03-23T20:04:05Z",
-      "language": "es"
-    },
-    {
-      "id": 4585,
-      "label": "soap_pumps_to_wash_hands",
-      "translation": "2-3 pumps",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:03:24Z",
-      "updated_at": "2020-03-23T20:04:13Z",
-      "language": "en"
-    },
-    {
-      "id": 4590,
-      "label": "your_fingers_and_under_your_fingernails",
-      "translation": "your fingers and under your fingernails ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:06:43Z",
-      "updated_at": "2020-03-23T20:06:43Z",
-      "language": "en"
-    },
-    {
-      "id": 4591,
-      "label": "your_fingers_and_under_your_fingernails",
-      "translation": "los dedos y debajo de las uñas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:07:00Z",
-      "updated_at": "2020-03-23T20:07:00Z",
-      "language": "es"
-    },
-    {
-      "id": 4592,
-      "label": "your_fingers_and_under_your_fingernails",
-      "translation": "Vos doigts et en-dessous des ongles",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:07:14Z",
-      "updated_at": "2020-03-23T20:07:14Z",
-      "language": "fr"
-    },
-    {
-      "id": 4593,
-      "label": "your_fingers_and_under_your_fingernails",
-      "translation": "dedos e sob as unhas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:07:23Z",
-      "updated_at": "2020-03-23T20:07:23Z",
-      "language": "pt"
-    },
-    {
-      "id": 4594,
-      "label": "your_fingers_and_under_your_fingernails",
-      "translation": "手指和指甲下",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:07:45Z",
-      "updated_at": "2020-03-23T20:07:45Z",
-      "language": "zh"
-    },
-    {
-      "id": 4595,
-      "label": "for_twenty_seconds",
-      "translation": "for 20 seconds",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:11:01Z",
-      "updated_at": "2020-03-23T20:11:27Z",
-      "language": "en"
-    },
-    {
-      "id": 4596,
-      "label": "for_twenty_seconds",
-      "translation": "durante 20 segundos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:11:34Z",
-      "updated_at": "2020-03-23T20:11:34Z",
-      "language": "es"
-    },
-    {
-      "id": 4597,
-      "label": "for_twenty_seconds",
-      "translation": "Pendant 20 secondes",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:11:42Z",
-      "updated_at": "2020-03-23T20:11:42Z",
-      "language": "fr"
-    },
-    {
-      "id": 4598,
-      "label": "for_twenty_seconds",
-      "translation": "por 20 segundos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:11:54Z",
-      "updated_at": "2020-03-23T20:11:54Z",
-      "language": "pt"
-    },
-    {
-      "id": 4599,
-      "label": "for_twenty_seconds",
-      "translation": "大约二十秒",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:12:09Z",
-      "updated_at": "2020-03-23T20:12:09Z",
-      "language": "zh"
-    },
-    {
-      "id": 4600,
-      "label": "paper_towel_or_air_dryer",
-      "translation": "paper towel or air dryer",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:27:30Z",
-      "updated_at": "2020-03-23T20:27:30Z",
-      "language": "en"
-    },
-    {
-      "id": 4601,
-      "label": "paper_towel_or_air_dryer",
-      "translation": "toalla de papel o secadores de mano",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:27:54Z",
-      "updated_at": "2020-03-23T20:27:54Z",
-      "language": "es"
-    },
-    {
-      "id": 4602,
-      "label": "paper_towel_or_air_dryer",
-      "translation": "Avec de l’essuie-tout ou un séchoir",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:28:02Z",
-      "updated_at": "2020-03-23T20:28:02Z",
-      "language": "fr"
-    },
-    {
-      "id": 4603,
-      "label": "paper_towel_or_air_dryer",
-      "translation": "toalha de papel ou secador de mãos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:28:11Z",
-      "updated_at": "2020-03-23T20:28:11Z",
-      "language": "pt"
-    },
-    {
-      "id": 4604,
-      "label": "paper_towel_or_air_dryer",
-      "translation": "用纸巾、厨房纸擦干或者用干手机烘干",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:28:22Z",
-      "updated_at": "2020-03-23T20:28:22Z",
-      "language": "zh"
-    },
-    {
-      "id": 4606,
-      "label": "alcohol_based_hand_sanitizer",
-      "translation": "以酒精为主要成分免洗洗手液",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:32:43Z",
-      "updated_at": "2020-03-23T20:32:43Z",
-      "language": "zh"
-    },
-    {
-      "id": 4605,
-      "label": "alcohol_based_hand_sanitizer",
-      "translation": "alcohol-based",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:32:33Z",
-      "updated_at": "2020-03-23T20:33:12Z",
-      "language": "en"
-    },
-    {
-      "id": 4607,
-      "label": "alcohol_based_hand_sanitizer",
-      "translation": "a base de alcohol",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:33:36Z",
-      "updated_at": "2020-03-23T20:33:36Z",
-      "language": "es"
-    },
-    {
-      "id": 4608,
-      "label": "alcohol_based_hand_sanitizer",
-      "translation": "D’alcool",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:33:58Z",
-      "updated_at": "2020-03-23T20:33:58Z",
-      "language": "fr"
-    },
-    {
-      "id": 4609,
-      "label": "alcohol_based_hand_sanitizer",
-      "translation": "à base de álcool",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:34:09Z",
-      "updated_at": "2020-03-23T20:34:09Z",
-      "language": "pt"
-    },
-    {
-      "id": 4611,
-      "label": "at_least_sixty_percent",
-      "translation": "60% 以上",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:36:20Z",
-      "updated_at": "2020-03-23T20:36:20Z",
-      "language": "zh"
-    },
-    {
-      "id": 4612,
-      "label": "at_least_sixty_percent",
-      "translation": "pelo menos 60%",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:36:27Z",
-      "updated_at": "2020-03-23T20:36:27Z",
-      "language": "pt"
-    },
-    {
-      "id": 4613,
-      "label": "at_least_sixty_percent",
-      "translation": "Au moins 60%",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:36:34Z",
-      "updated_at": "2020-03-23T20:36:34Z",
-      "language": "fr"
-    },
-    {
-      "id": 4614,
-      "label": "at_least_sixty_percent",
-      "translation": "al menos 60%",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:36:45Z",
-      "updated_at": "2020-03-23T20:36:45Z",
-      "language": "es"
-    },
-    {
-      "id": 4621,
-      "label": "yes",
-      "translation": "正确",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T20:48:52Z",
-      "updated_at": "2020-03-23T20:48:52Z",
-      "language": "zh"
-    },
-    {
-      "id": 4627,
-      "label": "off_and_unplugged",
-      "translation": "手机关机并且不在充电时",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T21:53:35Z",
-      "updated_at": "2020-03-23T21:53:35Z",
-      "language": "zh"
-    },
-    {
-      "id": 4628,
-      "label": "off_and_unplugged",
-      "translation": "desligado e desconectado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T21:54:46Z",
-      "updated_at": "2020-03-23T21:54:46Z",
-      "language": "pt"
-    },
-    {
-      "id": 4629,
-      "label": "off_and_unplugged",
-      "translation": "Éteint et débranché",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T21:54:54Z",
-      "updated_at": "2020-03-23T21:54:54Z",
-      "language": "fr"
-    },
-    {
-      "id": 4630,
-      "label": "off_and_unplugged",
-      "translation": "apagado y desconectado",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T21:55:07Z",
-      "updated_at": "2020-03-23T21:55:07Z",
-      "language": "es"
-    },
-    {
-      "id": 4631,
-      "label": "never",
-      "translation": "即便在戴手套的情况下，也需要洗手\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:07:13Z",
-      "updated_at": "2020-03-23T23:07:13Z",
-      "language": "zh"
-    },
-    {
-      "id": 4632,
-      "label": "he_coughed_into_them",
-      "translation": "he coughed into them",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:14:37Z",
-      "updated_at": "2020-03-23T23:14:37Z",
-      "language": "en"
-    },
-    {
-      "id": 4633,
-      "label": "he_coughed_into_them",
-      "translation": "他用手遮盖了他的咳嗽",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:15:14Z",
-      "updated_at": "2020-03-23T23:15:14Z",
-      "language": "zh"
-    },
-    {
-      "id": 4634,
-      "label": "he_coughed_into_them",
-      "translation": "ele tossiu para eles",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:16:12Z",
-      "updated_at": "2020-03-23T23:16:12Z",
-      "language": "pt"
-    },
-    {
-      "id": 4635,
-      "label": "he_coughed_into_them",
-      "translation": "il a toussé dans ses mains",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:16:23Z",
-      "updated_at": "2020-03-23T23:16:23Z",
-      "language": "fr"
-    },
-    {
-      "id": 4636,
-      "label": "he_coughed_into_them",
-      "translation": "tosió en ellas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:16:32Z",
-      "updated_at": "2020-03-23T23:16:32Z",
-      "language": "es"
-    },
-    {
-      "id": 4637,
-      "label": "wash_her_hands_before_and_after",
-      "translation": "wash her hands before and after",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:19:10Z",
-      "updated_at": "2020-03-23T23:19:10Z",
-      "language": "en"
-    },
-    {
-      "id": 4638,
-      "label": "wash_her_hands_before_and_after",
-      "translation": "饭前饭后都要洗手",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:19:20Z",
-      "updated_at": "2020-03-23T23:19:20Z",
-      "language": "zh"
-    },
-    {
-      "id": 4639,
-      "label": "wash_her_hands_before_and_after",
-      "translation": "lavarse las manos antes y después",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:19:48Z",
-      "updated_at": "2020-03-23T23:19:48Z",
-      "language": "es"
-    },
-    {
-      "id": 4640,
-      "label": "wash_her_hands_before_and_after",
-      "translation": "Se laver les mains avant et après",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:19:58Z",
-      "updated_at": "2020-03-23T23:19:58Z",
-      "language": "fr"
-    },
-    {
-      "id": 4641,
-      "label": "wash_her_hands_before_and_after",
-      "translation": "lave as mãos antes e depois",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:20:13Z",
-      "updated_at": "2020-03-23T23:20:13Z",
-      "language": "pt"
-    },
-    {
-      "id": 4642,
-      "label": "high_contact_surfaces",
-      "translation": "high-contact surfaces",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:22:47Z",
-      "updated_at": "2020-03-23T23:22:58Z",
-      "language": "en"
-    },
-    {
-      "id": 4643,
-      "label": "high_contact_surfaces",
-      "translation": "不经常接触的物体表面",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:23:09Z",
-      "updated_at": "2020-03-23T23:23:09Z",
-      "language": "zh"
-    },
-    {
-      "id": 4644,
-      "label": "high_contact_surfaces",
-      "translation": "superfícies de alto contato",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:23:21Z",
-      "updated_at": "2020-03-23T23:23:21Z",
-      "language": "pt"
-    },
-    {
-      "id": 4645,
-      "label": "high_contact_surfaces",
-      "translation": "Des surfaces de contact élevé",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:23:32Z",
-      "updated_at": "2020-03-23T23:23:32Z",
-      "language": "fr"
-    },
-    {
-      "id": 4646,
-      "label": "high_contact_surfaces",
-      "translation": "superficies de alto contacto",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:23:43Z",
-      "updated_at": "2020-03-23T23:23:43Z",
-      "language": "es"
-    },
-    {
-      "id": 4648,
-      "label": "up_to_twenty_four_hours",
-      "translation": "少于 24 小时",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:26:09Z",
-      "updated_at": "2020-03-23T23:26:09Z",
-      "language": "zh"
-    },
-    {
-      "id": 4649,
-      "label": "up_to_twenty_four_hours",
-      "translation": "até 24 horas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:26:31Z",
-      "updated_at": "2020-03-23T23:26:31Z",
-      "language": "pt"
-    },
-    {
-      "id": 4650,
-      "label": "up_to_twenty_four_hours",
-      "translation": "Jusqu’à 24h",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:26:46Z",
-      "updated_at": "2020-03-23T23:26:46Z",
-      "language": "fr"
-    },
-    {
-      "id": 4647,
-      "label": "up_to_twenty_four_hours",
-      "translation": "up to 24 hours",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:26:02Z",
-      "updated_at": "2020-03-23T23:26:53Z",
-      "language": "en"
-    },
-    {
-      "id": 4651,
-      "label": "up_to_twenty_four_hours",
-      "translation": "hasta 24 horas",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:27:03Z",
-      "updated_at": "2020-03-23T23:27:03Z",
-      "language": "es"
-    },
-    {
-      "id": 4652,
-      "label": "two_to_three_days",
-      "translation": "2-3 days",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:29:33Z",
-      "updated_at": "2020-03-23T23:29:43Z",
-      "language": "en"
-    },
-    {
-      "id": 4653,
-      "label": "two_to_three_days",
-      "translation": "2-3 dias",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:30:01Z",
-      "updated_at": "2020-03-23T23:30:01Z",
-      "language": "pt"
-    },
-    {
-      "id": 4654,
-      "label": "two_to_three_days",
-      "translation": "Pendant 2 à 3 jours",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:30:24Z",
-      "updated_at": "2020-03-23T23:30:24Z",
-      "language": "fr"
-    },
-    {
-      "id": 4655,
-      "label": "two_to_three_days",
-      "translation": "两三天",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:31:19Z",
-      "updated_at": "2020-03-23T23:31:19Z",
-      "language": "zh"
-    },
-    {
-      "id": 4656,
-      "label": "two_to_three_days",
-      "translation": "2-3 días",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:31:28Z",
-      "updated_at": "2020-03-23T23:31:28Z",
-      "language": "es"
-    },
-    {
-      "id": 4658,
-      "label": "clean_and_disinfect",
-      "translation": "清洁并消毒",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:33:33Z",
-      "updated_at": "2020-03-23T23:33:33Z",
-      "language": "zh"
-    },
-    {
-      "id": 4657,
-      "label": "clean_and_disinfect",
-      "translation": "clean & disinfect",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:33:26Z",
-      "updated_at": "2020-03-23T23:33:45Z",
-      "language": "en"
-    },
-    {
-      "id": 4659,
-      "label": "clean_and_disinfect",
-      "translation": "limpar e desinfectar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:33:57Z",
-      "updated_at": "2020-03-23T23:33:57Z",
-      "language": "pt"
-    },
-    {
-      "id": 4660,
-      "label": "clean_and_disinfect",
-      "translation": "Nettoyer & désinfecter",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:34:18Z",
-      "updated_at": "2020-03-23T23:34:18Z",
-      "language": "fr"
-    },
-    {
-      "id": 4661,
-      "label": "clean_and_disinfect",
-      "translation": "limpiar y desinfectar",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:34:29Z",
-      "updated_at": "2020-03-23T23:34:29Z",
-      "language": "es"
-    },
-    {
-      "id": 4663,
-      "label": "are_sixty_to_ninety_percent_alcohol_based",
-      "translation": "酒精含量在 60% - 90%之间",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:38:40Z",
-      "updated_at": "2020-03-23T23:38:40Z",
-      "language": "zh"
-    },
-    {
-      "id": 4662,
-      "label": "are_sixty_to_ninety_percent_alcohol_based",
-      "translation": "are 60-90% percent alcohol based",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:38:31Z",
-      "updated_at": "2020-03-23T23:38:53Z",
-      "language": "en"
-    },
-    {
-      "id": 4664,
-      "label": "are_sixty_to_ninety_percent_alcohol_based",
-      "translation": "sean 60-90% a base de alcohol ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:39:02Z",
-      "updated_at": "2020-03-23T23:39:02Z",
-      "language": "es"
-    },
-    {
-      "id": 4665,
-      "label": "are_sixty_to_ninety_percent_alcohol_based",
-      "translation": "Ils contiennent entre 60 et 90%",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:39:09Z",
-      "updated_at": "2020-03-23T23:39:09Z",
-      "language": "fr"
-    },
-    {
-      "id": 4666,
-      "label": "are_sixty_to_ninety_percent_alcohol_based",
-      "translation": "60-90% de álcool com base em",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T23:39:18Z",
-      "updated_at": "2020-03-23T23:39:18Z",
-      "language": "pt"
-    },
-    {
-      "id": 4500,
       "label": "drill_how_to_practice_2",
       "translation": "Quanto sabão você deve usar ao lavar as mãos?\n\na) 1 bomba\nb) 2-3 bombas\nc) nada",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:15:41Z",
-      "updated_at": "2020-03-23T23:57:19Z",
       "language": "pt"
     },
     {
-      "id": 4511,
       "label": "drill_how_to_practice_5",
       "translation": "Qual é a maneira mais segura de secar as mãos? \n\na) toalha de cozinha\nb) sacudindo-os\nc) deixe-os secar ao ar\nd) em sua camisa\ne) toalha de papel ou secador de mãos",
-      "translation_type": "lesson",
-      "created_at": "2020-03-22T22:47:14Z",
-      "updated_at": "2020-03-24T00:01:34Z",
       "language": "pt"
     },
     {
-      "id": 4366,
       "label": "disinfect_phone_practice_1",
       "translation": "El 80 por ciento de todas las infecciones se transmiten mediante [---]\n\na) las manos\nb) La tos\nc) estornudos\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:02:00Z",
-      "updated_at": "2020-03-24T00:09:51Z",
       "language": "es"
     },
     {
-      "id": 4224,
       "label": "covid_1_practice_1",
       "translation": "¿Verdadero o falso?\n\nCOVID-19 es una bacteria.\n\na) cierto\nb) falso",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:42:24Z",
-      "updated_at": "2020-03-24T00:35:16Z",
       "language": "es"
     },
     {
-      "id": 4108,
       "label": "drill_when_to_fact_4",
       "translation": "HECHO: ¡Tocamos mucho nuestros teléfonos -- 2,000 veces por día! El teléfono inteligente promedio tiene 15 veces más gérmenes en su superficie que un baño público. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-18T00:09:33Z",
-      "updated_at": "2020-03-24T01:32:40Z",
       "language": "es"
     },
     {
-      "id": 4240,
       "label": "covid_1_practice_3",
       "translation": "Répondez à la question. \n\nCommet le COVID-19 se propage-t-il d’une personne à une autre? \n\na) En étant en contact avec une personne infectée\nb) Par des gouttelettes projetées dans l’air quand une personne malade tousse ou éternue\nc) En touchant une surface sur laquelle le virus est présent, et en se touchant le visage ensuite\nd) Toutes les options ci-dessus\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-20T19:53:47Z",
-      "updated_at": "2020-03-24T02:14:10Z",
       "language": "fr"
     },
     {
-      "id": 4305,
       "label": "covid_prev_fact_2",
       "translation": "LES FAITS: Le COVID-19 se transmet principalement dans l’air par des gouttelettes respiratoires (quand une personne éternue ou tousse). Il faut garder ses distances avec les autres, se laver les mains, et ne pas se toucher le visage. ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T01:20:50Z",
-      "updated_at": "2020-03-24T02:22:14Z",
       "language": "fr"
     },
     {
-      "id": 4682,
       "label": "drill_reminder",
       "translation": "您快完成了！ 回答上一个问题。",
-      "translation_type": "system",
-      "created_at": "2020-03-11T19:42:05Z",
-      "updated_at": "2020-03-11T19:42:05Z",
       "language": "zh"
     },
     {
-      "id": 4437,
       "label": "high_contact_practice_5",
       "translation": "Pour empêcher la propagation du COVID-19 sur des surfaces fréquemment touchées, vous devez les [---] régulièrement. Utilisez de l’eau de javel ou un produit d’entretien désinfectant. \n\na) Nettoyer et désinfecter\nb) Aérer\nc) Essuyer\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-21T02:35:32Z",
-      "updated_at": "2020-03-24T03:59:08Z",
       "language": "fr"
     },
     {
-      "id": 3503,
       "label": "match_correct_answer",
       "translation": "🤖 Correto! {{emojis}}",
-      "translation_type": "system",
-      "created_at": "2020-03-09T21:24:00Z",
-      "updated_at": "2020-03-09T21:24:00Z",
       "language": "pt"
     },
     {
-      "id": 4683,
       "label": "match_correct_answer",
       "translation": "🤖 答对了! {{emojis}}",
-      "translation_type": "system",
-      "created_at": "2020-03-24T17:19:31Z",
-      "updated_at": "2020-03-24T17:19:31Z",
       "language": "zh"
     },
     {
-      "id": 4685,
       "label": "intake_whats_your_full_name",
       "translation": "你的全名是什么？\n（名字和姓氏）",
-      "translation_type": "lesson",
-      "created_at": "2020-03-25T01:07:27Z",
-      "updated_at": "2020-03-25T01:07:27Z",
       "language": "zh"
     },
     {
-      "id": 4549,
       "label": "high_contact_practice_5",
       "translation": "Para evitar espalhar o COVID-19 por superfícies de alto contato, você deve [---] freqüentemente. Utilize uma solução de água sanitária e água ou outra solução desinfetante doméstico. \n\na) limpar e desinfectar\nb) arejar\nc) poeira  ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-23T01:10:36Z",
-      "updated_at": "2020-03-25T01:10:12Z",
       "language": "pt"
     },
     {
-      "id": 4686,
       "label": "drill_complete_next",
       "translation": "You will get your next drill tomorrow afternoon! ",
-      "translation_type": "lesson",
-      "created_at": "2020-03-27T22:18:49Z",
-      "updated_at": "2020-03-27T22:19:08Z",
       "language": "en"
     },
     {
-      "id": 4687,
       "label": "drill_complete_next",
       "translation": "¡Tendrás tu próximo ejercicio mañana por la tarde!\n\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-27T22:19:21Z",
-      "updated_at": "2020-03-27T22:19:21Z",
       "language": "es"
     },
     {
-      "id": 4688,
       "label": "drill_complete_next",
       "translation": "Vous aurez votre prochain exercice demain après-midi!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-27T22:19:44Z",
-      "updated_at": "2020-03-27T22:19:44Z",
       "language": "fr"
     },
     {
-      "id": 4689,
       "label": "drill_complete_next",
       "translation": "Você fará seu próximo exercício amanhã à tarde!\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-27T22:19:53Z",
-      "updated_at": "2020-03-27T22:19:53Z",
       "language": "pt"
-    },
-    {
-      "id": 4691,
-      "label": "stop_covid_message_rates",
-      "translation": "El mensaje y las tarifas de datos pueden aplicarse.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-28T21:47:03Z",
-      "updated_at": "2020-03-28T21:47:03Z",
-      "language": "es"
-    },
-    {
-      "id": 4692,
-      "label": "stop_covid_message_rates",
-      "translation": "Des tarifs de messagerie et de données peuvent s'appliquer.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-28T21:47:20Z",
-      "updated_at": "2020-03-28T21:47:20Z",
-      "language": "fr"
-    },
-    {
-      "id": 4693,
-      "label": "stop_covid_message_rates",
-      "translation": "Podem ser aplicadas taxas de mensagens e dados.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-28T21:47:32Z",
-      "updated_at": "2020-03-28T21:47:32Z",
-      "language": "pt"
-    },
-    {
-      "id": 4695,
-      "label": "stop_covid_twilio_instructions",
-      "translation": "Envíeme la palabra AYUDA para obtener ayuda. Envíeme un mensaje de texto con la palabra STOP para optar por no participar.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-28T21:51:13Z",
-      "updated_at": "2020-03-28T21:51:13Z",
-      "language": "es"
-    },
-    {
-      "id": 4696,
-      "label": "stop_covid_twilio_instructions",
-      "translation": "Envie-me a palavra AJUDA para obter ajuda. Envie-me uma mensagem de texto com a palavra PARAR para escolher não participar.",
-      "translation_type": "lesson",
-      "created_at": "2020-03-28T21:51:55Z",
-      "updated_at": "2020-03-28T21:51:55Z",
-      "language": "pt"
-    },
-    {
-      "id": 4697,
-      "label": "stop_covid_twilio_instructions",
-      "translation": "Envoyez-moi le mot AIDE pour obtenir de l'aide. Envoyez-moi un SMS avec le mot STOP pour choisir de ne pas participer.\n",
-      "translation_type": "lesson",
-      "created_at": "2020-03-28T21:52:05Z",
-      "updated_at": "2020-03-28T21:52:05Z",
-      "language": "fr"
-    },
-    {
-      "id": 4690,
-      "label": "stop_covid_message_rates",
-      "translation": "Message and data rates may apply. Message frequency varies",
-      "translation_type": "lesson",
-      "created_at": "2020-03-28T21:43:55Z",
-      "updated_at": "2020-03-28T22:05:35Z",
-      "language": "en"
-    },
-    {
-      "id": 4694,
-      "label": "stop_covid_twilio_instructions",
-      "translation": "Text me the word HELP for help. Text me the word STOP to opt out.\n\nYou can view our privacy policy here: https:\/\/www.iubenda.com\/privacy-policy\/13453707\/full-legal",
-      "translation_type": "lesson",
-      "created_at": "2020-03-28T21:48:33Z",
-      "updated_at": "2020-03-28T22:15:04Z",
-      "language": "en"
     }
   ]
 }


### PR DESCRIPTION
This updates drill export that fixes message order and comes straight from the old api with no editing. This also contains translations that have been trimmed down to only include placeholders used in the drills along with system messages (most of which still aren't needed).