### PR TITLE
Mock boto instead of SQS

### DIFF
--- a/__tests__/stopcovid/test_event_distributor.py
+++ b/__tests__/stopcovid/test_event_distributor.py
@@ -6,19 +6,25 @@ from stopcovid.event_distributor import distribute_dialog_events
 
 
 class TestHandleCommand(unittest.TestCase):
-    @patch("stopcovid.clients.sqs.SQS")
-    def test_distribute_events(self, sqs_mock):
+    def _get_mocked_send_messages(self, boto_mock):
+        sqs_mock = MagicMock()
+        boto_mock.resource.return_value = sqs_mock
         queue = MagicMock(name="queue")
-        send_messages = MagicMock()
-        queue.send_messages = send_messages
+        send_messages_mock = MagicMock()
+        queue.send_messages = send_messages_mock
         sqs_mock.get_queue_by_name = MagicMock(return_value=queue)
+        return send_messages_mock
+
+    @patch("stopcovid.clients.sqs.boto3")
+    def test_distribute_events(self, boto_mock):
+        send_messages_mock = self._get_mocked_send_messages(boto_mock)
 
         with open("sample_events/distribute_event.json") as f:
             mock_event = json.load(f)
         distribute_dialog_events(mock_event, None)
 
-        send_messages.assert_called_once()
-        call = send_messages.mock_calls[0]
+        send_messages_mock.assert_called_once()
+        call = send_messages_mock.mock_calls[0]
         _, *kwargs = call
 
         entries = kwargs[1]["Entries"]

--- a/stopcovid/clients/sqs.py
+++ b/stopcovid/clients/sqs.py
@@ -4,8 +4,6 @@ import json
 from typing import List
 from dataclasses import dataclass
 
-SQS = boto3.resource("sqs")
-
 
 @dataclass
 class OutboundSMS:
@@ -15,8 +13,10 @@ class OutboundSMS:
 
 
 def publish_outbound_sms_messages(outbound_sms_messages: List[OutboundSMS]):
+    sqs = boto3.resource("sqs")
+
     queue_name = f"outbound-sms-{os.getenv('STAGE')}"
-    queue = SQS.get_queue_by_name(QueueName=queue_name)
+    queue = sqs.get_queue_by_name(QueueName=queue_name)
 
     entries = [
         {


### PR DESCRIPTION
We were mocking SQS at runtime, which means at file load time it was actually initializing an sqs client from boto3, which required properly configured credentials in `~/.aws/credentials`. Yuck.  Mocking boto3 itself should fix this