### PR TITLE
support for help, stop, opt-back-in, and more

### DIFF
--- a/__tests__/stopcovid/dialog/test_dialog.py
+++ b/__tests__/stopcovid/dialog/test_dialog.py
@@ -20,6 +20,8 @@ from stopcovid.dialog.dialog import (
     ReminderTriggered,
     UserValidationFailed,
     UserValidated,
+    OptedOut,
+    NextDrillRequested,
 )
 from stopcovid.dialog.types import (
     DialogEvent,
@@ -553,6 +555,40 @@ class TestDrillCompleted(unittest.TestCase):
         self.assertIsNone(dialog_state.current_drill)
 
 
+class TestOptedOut(unittest.TestCase):
+    def test_opted_out(self):
+        profile = UserProfile(validated=True)
+        event = OptedOut("123456789", user_profile=profile, drill_instance_id=uuid.uuid4())
+        dialog_state = DialogState(
+            "123456789",
+            seq="0",
+            user_profile=profile,
+            current_drill=DRILL,
+            drill_instance_id=event.drill_instance_id,
+            current_prompt_state=PromptState(DRILL.prompts[-1].slug, start_time=NOW),
+        )
+
+        self.assertFalse(profile.opted_out)
+        event.apply_to(dialog_state)
+        self.assertTrue(profile.opted_out)
+        self.assertIsNone(dialog_state.drill_instance_id)
+        self.assertIsNone(dialog_state.current_prompt_state)
+        self.assertIsNone(dialog_state.current_drill)
+
+
+class TestNextDrillRequested(unittest.TestCase):
+    def test_next_drill_requested(self):
+        profile = UserProfile(validated=True, opted_out=True)
+        event = NextDrillRequested(
+            "123456789", user_profile=profile, drill_instance_id=uuid.uuid4()
+        )
+        dialog_state = DialogState("123456789", seq="0", user_profile=profile)
+
+        self.assertTrue(profile.opted_out)
+        event.apply_to(dialog_state)
+        self.assertFalse(profile.opted_out)
+
+
 class TestSerialization(unittest.TestCase):
     def setUp(self) -> None:
         self.prompt = Prompt(
@@ -662,6 +698,21 @@ class TestSerialization(unittest.TestCase):
 
     def test_user_validation_failed(self):
         original = UserValidationFailed("123456789", user_profile=UserProfile(True))
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+
+    def test_opted_out(self):
+        original = OptedOut(
+            "123456789", user_profile=UserProfile(True), drill_instance_id=uuid.uuid4()
+        )
+        serialized = original.to_dict()
+        deserialized = event_from_dict(serialized)
+        self._make_base_assertions(original, deserialized)
+        self.assertEqual(original.drill_instance_id, deserialized.drill_instance_id)
+
+    def test_next_drill_requested(self):
+        original = NextDrillRequested("123456789", user_profile=UserProfile(True))
         serialized = original.to_dict()
         deserialized = event_from_dict(serialized)
         self._make_base_assertions(original, deserialized)

--- a/__tests__/stopcovid/dialog/test_dialog.py
+++ b/__tests__/stopcovid/dialog/test_dialog.py
@@ -707,7 +707,7 @@ class TestSerialization(unittest.TestCase):
             "123456789", user_profile=UserProfile(True), drill_instance_id=uuid.uuid4()
         )
         serialized = original.to_dict()
-        deserialized = event_from_dict(serialized)
+        deserialized: OptedOut = event_from_dict(serialized)  # type: ignore
         self._make_base_assertions(original, deserialized)
         self.assertEqual(original.drill_instance_id, deserialized.drill_instance_id)
 

--- a/__tests__/stopcovid/status/test_initiation.py
+++ b/__tests__/stopcovid/status/test_initiation.py
@@ -120,3 +120,22 @@ class TestRecordInitiation(unittest.TestCase):
             self.assertEqual(1, self.put_records_mock.call_count)
             self.initiator.trigger_next_drills()
             self.assertEqual(1, self.put_records_mock.call_count)
+
+    def test_initiation_next_drill_for_user(self, get_kinesis_mock):
+        get_kinesis_mock.return_value = self.kinesis_mock
+
+        phone_number = str(uuid.uuid4())
+        user_id = uuid.uuid4()
+        with patch(
+            "stopcovid.status.initiation.UserRepository.get_progress_for_user",
+            return_value=DrillProgress(
+                phone_number=phone_number,
+                user_id=user_id,
+                first_incomplete_drill_slug="02-prevention",
+                first_unstarted_drill_slug="03-hand-washing-how",
+            ),
+        ):
+            self.initiator.trigger_next_drill_for_user(user_id, phone_number, "foo")
+            self.assertEqual(1, self.put_records_mock.call_count)
+            self.initiator.trigger_next_drill_for_user(user_id, phone_number, "foo")
+            self.assertEqual(1, self.put_records_mock.call_count)

--- a/__tests__/stopcovid/status/test_status.py
+++ b/__tests__/stopcovid/status/test_status.py
@@ -1,10 +1,10 @@
 import unittest
 
-from stopcovid.dialog.dialog import UserValidated, DrillStarted
+from stopcovid.dialog.dialog import UserValidated, DrillStarted, NextDrillRequested
 from stopcovid.dialog.registration import CodeValidationPayload
 from stopcovid.dialog.types import DialogEventBatch, UserProfile
 from stopcovid.drills.drills import get_drill
-from stopcovid.status.status import initiates_first_drill
+from stopcovid.status.status import initiates_first_drill, initiates_subsequent_drill
 
 
 class TestStatus(unittest.TestCase):
@@ -43,3 +43,36 @@ class TestStatus(unittest.TestCase):
         )
         self.assertTrue(initiates_first_drill(batch1))
         self.assertFalse(initiates_first_drill(batch2))
+
+    def test_initiates_subsequent_drill(self):
+        batch1 = DialogEventBatch(
+            phone_number="123456789",
+            seq="0",
+            events=[
+                NextDrillRequested(
+                    phone_number="123456789",
+                    user_profile=UserProfile(True),
+                    code_validation_payload=CodeValidationPayload(valid=True),
+                ),
+                DrillStarted(
+                    phone_number="123456789",
+                    user_profile=UserProfile(True),
+                    drill=self.drill,
+                    first_prompt=self.drill.prompts[0],
+                ),
+            ],
+        )
+        batch2 = DialogEventBatch(
+            phone_number="987654321",
+            seq="1",
+            events=[
+                DrillStarted(
+                    phone_number="987654321",
+                    user_profile=UserProfile(True),
+                    drill=self.drill,
+                    first_prompt=self.drill.prompts[0],
+                )
+            ],
+        )
+        self.assertTrue(initiates_subsequent_drill(batch1))
+        self.assertFalse(initiates_subsequent_drill(batch2))

--- a/stopcovid/dialog/dialog.py
+++ b/stopcovid/dialog/dialog.py
@@ -96,7 +96,7 @@ class ProcessSMSMessage(types.Command):
             registration_validator = DEFAULT_REGISTRATION_VALIDATOR
         self.registration_validator = registration_validator
 
-    def execute(self, dialog_state: types.DialogState) -> List[types.DialogEvent]:
+    def execute(self, dialog_state: types.DialogState) -> List[types.DialogEvent]:  # noqa: C901
         base_args = {"phone_number": self.phone_number, "user_profile": dialog_state.user_profile}
 
         if self.content_lower == "help":

--- a/stopcovid/dialog/dialog.py
+++ b/stopcovid/dialog/dialog.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from copy import deepcopy
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Type
 
 from marshmallow import fields, post_load, utils
 
@@ -467,29 +467,23 @@ class NextDrillRequested(types.DialogEvent):
         dialog_state.user_profile.opted_out = False
 
 
+TYPE_TO_SCHEMA: Dict[types.DialogEventType, Type[types.DialogEventSchema]] = {
+    types.DialogEventType.ADVANCED_TO_NEXT_PROMPT: AdvancedToNextPromptSchema,
+    types.DialogEventType.DRILL_COMPLETED: DrillCompletedSchema,
+    types.DialogEventType.USER_VALIDATION_FAILED: UserValidationFailedSchema,
+    types.DialogEventType.DRILL_STARTED: DrillStartedSchema,
+    types.DialogEventType.USER_VALIDATED: UserValidatedSchema,
+    types.DialogEventType.COMPLETED_PROMPT: CompletedPromptSchema,
+    types.DialogEventType.FAILED_PROMPT: FailedPromptSchema,
+    types.DialogEventType.REMINDER_TRIGGERED: ReminderTriggeredSchema,
+    types.DialogEventType.OPTED_OUT: OptedOutSchema,
+    types.DialogEventType.NEXT_DRILL_REQUESTED: NextDrillRequestedSchema,
+}
+
+
 def event_from_dict(event_dict: Dict[str, Any]) -> types.DialogEvent:
     event_type = types.DialogEventType[event_dict["event_type"]]
-    if event_type == types.DialogEventType.ADVANCED_TO_NEXT_PROMPT:
-        return AdvancedToNextPromptSchema().load(event_dict)
-    if event_type == types.DialogEventType.DRILL_COMPLETED:
-        return DrillCompletedSchema().load(event_dict)
-    if event_type == types.DialogEventType.USER_VALIDATION_FAILED:
-        return UserValidationFailedSchema().load(event_dict)
-    if event_type == types.DialogEventType.DRILL_STARTED:
-        return DrillStartedSchema().load(event_dict)
-    if event_type == types.DialogEventType.USER_VALIDATED:
-        return UserValidatedSchema().load(event_dict)
-    if event_type == types.DialogEventType.COMPLETED_PROMPT:
-        return CompletedPromptSchema().load(event_dict)
-    if event_type == types.DialogEventType.FAILED_PROMPT:
-        return FailedPromptSchema().load(event_dict)
-    if event_type == types.DialogEventType.REMINDER_TRIGGERED:
-        return ReminderTriggeredSchema().load(event_dict)
-    if event_type == types.DialogEventType.OPTED_OUT:
-        return OptedOutSchema().load(event_dict)
-    if event_type == types.DialogEventType.NEXT_DRILL_REQUESTED:
-        return NextDrillRequestedSchema().load(event_dict)
-    raise ValueError(f"unknown event type {event_type}")
+    return TYPE_TO_SCHEMA[event_type]().load(event_dict)
 
 
 def batch_from_dict(batch_dict: Dict[str, Any]) -> types.DialogEventBatch:

--- a/stopcovid/dialog/types.py
+++ b/stopcovid/dialog/types.py
@@ -14,6 +14,7 @@ SCHEMA_VERSION = 1
 
 class UserProfileSchema(Schema):
     validated = fields.Boolean(required=True)
+    opted_out = fields.Boolean(missing=False)
     language = fields.Str(allow_none=True)
     name = fields.Str(allow_none=True)
     account_info = fields.Mapping(keys=fields.Str(), allow_none=True)
@@ -34,6 +35,7 @@ class UserProfileSchema(Schema):
 @dataclass
 class UserProfile:
     validated: bool
+    opted_out: bool = False
     is_demo: bool = False
     name: Optional[str] = None
     language: Optional[str] = None
@@ -121,6 +123,8 @@ class DialogEventType(enum.Enum):
     FAILED_PROMPT = "FAILED_PROMPT"
     ADVANCED_TO_NEXT_PROMPT = "ADVANCED_TO_NEXT_PROMPT"
     DRILL_COMPLETED = "DRILL_COMPLETED"
+    NEXT_DRILL_REQUESTED = "NEXT_DRILL_REQUESTED"
+    OPTED_OUT = "OPTED_OUT"
 
 
 class EventTypeField(fields.Field):

--- a/stopcovid/event_distributor/outbound_sms.py
+++ b/stopcovid/event_distributor/outbound_sms.py
@@ -11,6 +11,8 @@ from stopcovid.dialog.dialog import (
     UserValidated,
     DrillStarted,
     UserValidationFailed,
+    NextDrillRequested,
+    OptedOut,
 )
 from stopcovid.drills.localize import localize
 
@@ -83,7 +85,11 @@ def get_messages_for_command(event: DialogEvent):  # noqa: C901
             event, [message.text for message in event.first_prompt.messages]
         )
 
-    elif isinstance(event, DrillCompleted):
+    elif (
+        isinstance(event, DrillCompleted)
+        or isinstance(event, OptedOut)
+        or isinstance(event, NextDrillRequested)
+    ):
         # Drills include a drill completed message
         pass
 

--- a/stopcovid/status/drill_instances.py
+++ b/stopcovid/status/drill_instances.py
@@ -30,6 +30,8 @@ from stopcovid.dialog.dialog import (
     UserValidated,
     UserValidationFailed,
     ReminderTriggered,
+    NextDrillRequested,
+    OptedOut,
 )
 from stopcovid.dialog.types import DialogEventBatch
 from . import db
@@ -78,6 +80,10 @@ class DrillInstanceRepository:
                         self._invalidate_prior_drills(user_id, batch.seq, connection)
                     elif isinstance(event, DrillStarted):
                         self._record_new_drill_instance(user_id, event, batch.seq, connection)
+                    elif isinstance(event, OptedOut):
+                        self._invalidate_drill_instance(
+                            event.drill_instance_id, batch.seq, connection
+                        )
                     elif isinstance(event, DrillCompleted):
                         self._mark_drill_instance_complete(event, batch.seq, connection)
                     elif isinstance(event, CompletedPrompt):
@@ -86,8 +92,10 @@ class DrillInstanceRepository:
                         self._update_current_prompt_response_time(event, batch.seq, connection)
                     elif isinstance(event, AdvancedToNextPrompt):
                         self._update_current_prompt(event, batch.seq, connection)
-                    elif isinstance(event, ReminderTriggered) or isinstance(
-                        event, UserValidationFailed
+                    elif (
+                        isinstance(event, ReminderTriggered)
+                        or isinstance(event, UserValidationFailed)
+                        or isinstance(event, NextDrillRequested)
                     ):
                         logging.info(f"Ignoring event of type {event.event_type}")
                     else:
@@ -118,6 +126,18 @@ class DrillInstanceRepository:
             )
             .values(is_valid=False)
         )
+
+    def _invalidate_drill_instance(
+        self, drill_instance_id: Optional[uuid.UUID], seq: str, connection
+    ):
+        if drill_instance_id is None:
+            return
+        if self._is_not_stale(drill_instance_id, seq, connection):
+            connection.execute(
+                drill_instances.update()
+                .where(drill_instances.c.drill_instance_id == func.uuid(str(drill_instance_id)))
+                .values(is_valid=False, seq=seq)
+            )
 
     def _record_new_drill_instance(
         self, user_id: uuid.UUID, event: DrillStarted, seq: str, connection
@@ -176,7 +196,8 @@ class DrillInstanceRepository:
                 )
             )
 
-    def _deserialize(self, row):
+    @staticmethod
+    def _deserialize(row):
         return DrillInstance(
             drill_instance_id=uuid.UUID(row["drill_instance_id"]),
             seq=row["seq"],
@@ -234,7 +255,7 @@ class DrillInstanceRepository:
 
     def get_incomplete_drills(self, inactive_for_minutes=None) -> List[DrillInstance]:
         stmt = select([drill_instances]).where(
-            and_(drill_instances.c.completion_time == None, drill_instances.c.is_valid.is_(True))
+            and_(drill_instances.c.completion_time.is_(None), drill_instances.c.is_valid.is_(True))
         )  # noqa:  E711
         if inactive_for_minutes is not None:
             stmt = stmt.where(

--- a/stopcovid/status/status.py
+++ b/stopcovid/status/status.py
@@ -4,7 +4,7 @@ from stopcovid.dialog.types import DialogEventBatch
 from .drill_instances import DrillInstanceRepository
 from .initiation import DrillInitiator
 from .users import UserRepository
-from ..dialog.dialog import UserValidated
+from ..dialog.dialog import UserValidated, NextDrillRequested
 
 
 def handle_dialog_event_batches(batches: List[DialogEventBatch]):
@@ -19,8 +19,14 @@ def handle_dialog_event_batches(batches: List[DialogEventBatch]):
     drill_instance_repo = DrillInstanceRepository()
     for batch in batches:
         user_id = user_repo.update_user(batch)
+        if initiates_subsequent_drill(batch):
+            initiator.trigger_next_drill_for_user(user_id, batch.phone_number, str(batch.batch_id))
         drill_instance_repo.update_drill_instances(user_id, batch)
 
 
 def initiates_first_drill(batch: DialogEventBatch):
     return any(event for event in batch.events if isinstance(event, UserValidated))
+
+
+def initiates_subsequent_drill(batch: DialogEventBatch):
+    return any(event for event in batch.events if isinstance(event, NextDrillRequested))


### PR DESCRIPTION
Question for Kai: Are help, stop, more, and start localized or should we look for the English words only?

* New events introduced: OptedOut and NextDrillRequested
* Updated dialog agent to produce and handle these events
* SMS sending gracefully ignores the new events
* Drill initiation now supports launching a new drill when it gets NextDrillRequested
* Status context forgets you've started a drill if you opt-out in the middle of that drill
* Updated simulator to support opt-out and more