### PR TITLE
Remove healthcheck

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -102,15 +102,6 @@ functions:
     events:
       - schedule: cron(5 17 * * ? *)
 
-  healthcheck:
-    handler: stopcovid/healthcheck.healthcheck
-    events:
-      - http:
-          path: /healthcheck
-          method: get
-          cors: true
-
-
 resources:
   Resources:
     AWSLambdaVPCAccessExecutionRole:

--- a/stopcovid/healthcheck.py
+++ b/stopcovid/healthcheck.py
@@ -1,2 +1,0 @@
-def healthcheck(event, context):
-    return {"statusCode": 200}


### PR DESCRIPTION
This isn't used for anything. I added it early on to help myself understand serverless deploys