### PR TITLE
retry command stream errors 10k times

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -145,6 +145,7 @@ resources:
             - HandleCommandLambdaFunction
             - Arn
         StartingPosition: LATEST
+        MaximumRetryAttempts: 10000
 
     # MESSAGE LOG STREAM
     MessageLogStream:
@@ -165,6 +166,7 @@ resources:
             - LogMessageLambdaFunction
             - Arn
         StartingPosition: LATEST
+        MaximumRetryAttempts: 10000
 
     # DB CLUSTER
     AuroraCluster:


### PR DESCRIPTION
DynamoDB stream processing errors were getting retried 10000 times. But kinesis stream errors were only getting retried 3 times.