### PR TITLE
Bump queue visibility to match lambda timeout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -192,6 +192,7 @@ resources:
       Properties:
         QueueName: outbound-sms-${self:provider.stage}.fifo
         FifoQueue: true
+        VisibilityTimeout: 60
         RedrivePolicy:
           deadLetterTargetArn:
             Fn::GetAtt:


### PR DESCRIPTION
This caused our prod deploy to fail. Cloudformation needs the queue visibiliy timeout to be >= lambda timeout. My bet is that AWS added more validation between us deploying this event mapping to dev, and us deploying to prod just now.