### PR TITLE
Add created_at to sql alchemy schema

### DIFF
--- a/stopcovid/message_log/persistence.py
+++ b/stopcovid/message_log/persistence.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import List
 
-from sqlalchemy import Table, MetaData, Column, String, select, insert
+from sqlalchemy import Table, MetaData, Column, String, select, insert, DateTime, func
 from sqlalchemy.dialects.postgresql import UUID
 
 from sqlalchemy.exc import DatabaseError
@@ -13,6 +13,7 @@ messages = Table(
     "messages",
     metadata,
     Column("id", UUID(as_uuid=True), primary_key=True),
+    Column("created_at", DateTime(timezone=True), server_default=func.now()),
     Column("twilio_message_id", String, nullable=False, index=True, unique=True),
     Column("from_number", String, nullable=True, index=True),
     Column("to_number", String, nullable=False, index=True),


### PR DESCRIPTION
SQL alchemy spits out the following schema for create table:
```
CREATE TABLE messages (
	id UUID NOT NULL,
	created_at TIMESTAMP WITH TIME ZONE DEFAULT now(),
	twilio_message_id VARCHAR NOT NULL,
	from_number VARCHAR,
	to_number VARCHAR NOT NULL,
	body VARCHAR NOT NULL,
	status VARCHAR NOT NULL,
	PRIMARY KEY (id)
)
```

Deploy strategy:

1. I'll run the following commands in the query editor for the dev database:
`ALTER TABLE messages ADD COLUMN created_at TIMESTAMP DEFAULT NOW();
UPDATE messages SET created_at = null;`

2. Deploy to dev

3. Make sure new messages get created_at set correctly

4. Run the command above in the prod database

5. Deploy to prod

6. validate prod

7. Backfill dev and prod with the proper timezones by pulling from the twilio api


call me #backfillbinay
