### PR TITLE
Replace account_info on users table with profile

### DIFF
--- a/__tests__/stopcovid/status/test_drill_progress.py
+++ b/__tests__/stopcovid/status/test_drill_progress.py
@@ -41,7 +41,9 @@ class TestUsers(unittest.TestCase):
                 DrillCompleted(
                     phone_number=self.phone_number,
                     user_profile=UserProfile(
-                        True, account_info={"employer_id": Decimal(123), "unit_id": Decimal(456)}
+                        True,
+                        language="zh",
+                        account_info={"employer_id": Decimal(123), "unit_id": Decimal(456)},
                     ),
                     drill_instance_id=uuid.uuid4(),
                 )
@@ -50,7 +52,9 @@ class TestUsers(unittest.TestCase):
         user_id = self.repo._create_or_update_user(batch, self.repo.engine)
         user = self.repo.get_user(user_id)
         self.assertEqual(user_id, user.user_id)
-        self.assertEqual({"employer_id": 123, "unit_id": 456}, user.account_info)
+        self.assertEqual({"employer_id": 123, "unit_id": 456}, user.profile["account_info"])
+        self.assertEqual(True, user.profile["validated"])
+        self.assertEqual("zh", user.profile["language"])
         self.assertIsNone(user.last_interacted_time)
         self.assertEqual(batch.seq, user.seq)
 
@@ -66,7 +70,7 @@ class TestUsers(unittest.TestCase):
 
         self.repo._create_or_update_user(batch2, self.repo.engine)
         user = self.repo.get_user(user_id)
-        self.assertEqual({"foo": "bar", "one": "two"}, user.account_info)
+        self.assertEqual({"foo": "bar", "one": "two"}, user.profile["account_info"])
         self.assertEqual(batch2.seq, user.seq)
 
     def _make_user_and_get_id(self, **overrides) -> uuid.UUID:

--- a/__tests__/stopcovid/status/test_state.py
+++ b/__tests__/stopcovid/status/test_state.py
@@ -1,5 +1,4 @@
 import unittest
-import uuid
 from decimal import Decimal
 
 
@@ -13,14 +12,20 @@ class TestUserProfile(unittest.TestCase):
             is_demo=True,
             name="Devin Booker",
             language="en",
-            account_info={"employer_id": Decimal(91), "a_uuid": uuid.uuid4()},
+            account_info={"employer_id": Decimal(91), "unit_id": Decimal(19)},
         )
         expected = {
             "validated": True,
             "is_demo": True,
             "name": "Devin Booker",
             "language": "en",
-            "account_info": {"employer_id": 91, "a_uuid": str(profile.account_info["a_uuid"])},
+            "account_info": {"employer_id": 91, "unit_id": 19},
             "opted_out": False,
         }
-        self.assertDictContainsSubset(expected, profile.json_serialize())
+
+        print(profile.to_dict())
+        self.assertDictContainsSubset(expected, profile.to_dict())
+        # self.assertTrue(set(expected.items()).issubset( set(profile.to_dict().items()) ))
+        # And changes are immutabe
+        assert expected.items() <= profile.to_dict().items()
+        self.assertEqual(profile.account_info["employer_id"], Decimal(91))

--- a/__tests__/stopcovid/status/test_state.py
+++ b/__tests__/stopcovid/status/test_state.py
@@ -1,0 +1,26 @@
+import unittest
+import uuid
+from decimal import Decimal
+
+
+from stopcovid.dialog.models.state import UserProfile
+
+
+class TestUserProfile(unittest.TestCase):
+    def test_json_serialize_user_profile_handles_decimals_and_uuids(self):
+        profile = UserProfile(
+            validated=True,
+            is_demo=True,
+            name="Devin Booker",
+            language="en",
+            account_info={"employer_id": Decimal(91), "a_uuid": uuid.uuid4()},
+        )
+        expected = {
+            "validated": True,
+            "is_demo": True,
+            "name": "Devin Booker",
+            "language": "en",
+            "account_info": {"employer_id": 91, "a_uuid": str(profile.account_info["a_uuid"])},
+            "opted_out": False,
+        }
+        self.assertDictContainsSubset(expected, profile.json_serialize())

--- a/__tests__/stopcovid/status/test_state.py
+++ b/__tests__/stopcovid/status/test_state.py
@@ -23,9 +23,4 @@ class TestUserProfile(unittest.TestCase):
             "opted_out": False,
         }
 
-        print(profile.to_dict())
         self.assertDictContainsSubset(expected, profile.to_dict())
-        # self.assertTrue(set(expected.items()).issubset( set(profile.to_dict().items()) ))
-        # And changes are immutabe
-        assert expected.items() <= profile.to_dict().items()
-        self.assertEqual(profile.account_info["employer_id"], Decimal(91))

--- a/stopcovid/dialog/models/state.py
+++ b/stopcovid/dialog/models/state.py
@@ -1,6 +1,7 @@
 import uuid
 import datetime
-from dataclasses import dataclass, field
+from decimal import Decimal
+from dataclasses import dataclass, field, asdict
 from typing import Optional, Dict, Any
 
 from marshmallow import Schema, fields, post_load
@@ -47,6 +48,22 @@ class UserProfile:
 
     def __str__(self):
         return f"lang={self.language}, validated={self.validated}, " f"name={self.name}"
+
+    def json_serialize(self):
+        base = asdict(self)
+
+        def recursive_jsonify(obj):
+            for key in obj:
+                val = obj[key]
+                if isinstance(val, dict):
+                    obj[key] = recursive_jsonify(val)
+                if isinstance(val, Decimal):
+                    obj[key] = int(val)
+                if isinstance(val, uuid.UUID):
+                    obj[key] = str(val)
+            return obj
+
+        return recursive_jsonify(base)
 
 
 class PromptStateSchema(Schema):

--- a/stopcovid/status/drill_progress.py
+++ b/stopcovid/status/drill_progress.py
@@ -389,7 +389,7 @@ class DrillProgressRepository:
     ) -> uuid.UUID:
         event = batch.events[-1]
         phone_number = event.phone_number
-        profile = event.user_profile.json_serialize()
+        profile = event.user_profile.to_dict()
         result = connection.execute(
             select([phone_numbers]).where(phone_numbers.c.phone_number == phone_number)
         )

--- a/stopcovid/status/drill_progress.py
+++ b/stopcovid/status/drill_progress.py
@@ -354,7 +354,7 @@ class DrillProgressRepository:
     def _create_or_update_user(self, batch: DialogEventBatch, connection) -> uuid.UUID:
         event = batch.events[-1]
         phone_number = event.phone_number
-        profile = event.user_profile
+        profile = event.user_profile.json_serialize()
         result = connection.execute(
             select([phone_numbers]).where(phone_numbers.c.phone_number == phone_number)
         )
@@ -367,9 +367,7 @@ class DrillProgressRepository:
             )
             connection.execute(
                 users.insert().values(
-                    user_id=str(user_record.user_id),
-                    profile=user_record.profile.json_serialize(),
-                    seq=batch.seq,
+                    user_id=str(user_record.user_id), profile=user_record.profile, seq=batch.seq,
                 )
             )
             connection.execute(
@@ -404,7 +402,7 @@ class DrillProgressRepository:
         connection.execute(
             users.update()
             .where(users.c.user_id == func.uuid(str(phone_number_record.user_id)))
-            .values(profile=profile.json_serialize(), seq=batch.seq,)
+            .values(profile=profile, seq=batch.seq,)
         )
         return phone_number_record.user_id
 

--- a/stopcovid/status/drill_progress.py
+++ b/stopcovid/status/drill_progress.py
@@ -59,7 +59,7 @@ users = Table(
     metadata,
     Column("user_id", UUID, primary_key=True),
     Column("seq", String, nullable=False),
-    Column("profile", JSONB, nullable=True),
+    Column("profile", JSONB, nullable=False),
     Column("last_interacted_time", DateTime(timezone=True), index=True),
 )
 


### PR DESCRIPTION
Will run the following sql in dev before deploy:

```
ALTER TABLE users DROP COLUMN account_info;
ALTER TABLE users ADD profile jsonb;
UPDATE users SET profile={};
ALTER TABLE users ALTER COLUMN profile SET NOT NULL;

```

After that, ill run Phil's script to rebuilt all of the users in dev and validate that everything looks right. After that, ill move onto prod.