### PR TITLE
don't set the DB engine factory to None by default

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -156,7 +156,7 @@ def replay_message_stream(args):
                 f"{milliseconds_from_tip} from tip of shard {shard_id}. Handling {len(commands)} commands"
             )
             if commands:
-                log_messages(commands, engine_factory)
+                log_messages(commands, engine_factory=engine_factory)
 
 
 def main():

--- a/stopcovid/message_log/message_log.py
+++ b/stopcovid/message_log/message_log.py
@@ -22,6 +22,6 @@ def _command_to_dict(command: LogMessageCommand):
     }
 
 
-def log_messages(commands: List[LogMessageCommand], db_engine_factory=None):
-    message_repo = persistence.MessageRepository(engine_factory=db_engine_factory)
+def log_messages(commands: List[LogMessageCommand], **kwargs):
+    message_repo = persistence.MessageRepository(**kwargs)
     message_repo.upsert_messages([_command_to_dict(c) for c in commands])


### PR DESCRIPTION
by setting to None, we override the default. Using **kwargs so that we don't override the default.