### PR TITLE
Return twiml from webhook

### DIFF
--- a/aws_lambdas/twilio_webhook.py
+++ b/aws_lambdas/twilio_webhook.py
@@ -7,6 +7,7 @@ from urllib.parse import unquote_plus
 
 import boto3
 from twilio.request_validator import RequestValidator
+from twilio.twiml.messaging_response import MessagingResponse
 
 from stopcovid.dialog.command_stream.publish import CommandPublisher
 from stopcovid.utils import dynamodb as dynamodb_utils
@@ -48,7 +49,7 @@ def handler(event, context):
         )
 
     record_as_processed(idempotency_key, stage)
-    return {"statusCode": 200}
+    return MessagingResponse()
 
 
 def extract_form(event):

--- a/aws_lambdas/twilio_webhook.py
+++ b/aws_lambdas/twilio_webhook.py
@@ -52,7 +52,7 @@ def handler(event, context):
     return {
         "statusCode": 200,
         "headers": {"content-type": "application/xml"},
-        "body": MessagingResponse(),
+        "body": str(MessagingResponse()),
     }
 
 

--- a/aws_lambdas/twilio_webhook.py
+++ b/aws_lambdas/twilio_webhook.py
@@ -49,7 +49,11 @@ def handler(event, context):
         )
 
     record_as_processed(idempotency_key, stage)
-    return MessagingResponse()
+    return {
+        "statusCode": 200,
+        "headers": {"content-type": "application/xml"},
+        "body": MessagingResponse(),
+    }
 
 
 def extract_form(event):


### PR DESCRIPTION
Judging by this doc it looks like we want to return twiml directly, rather than a payload:
https://www.twilio.com/docs/sms/tutorials/how-to-receive-and-reply-python-amazon-lambda

An empty MessagingResponse() stringifies to:
`<?xml version="1.0" encoding="UTF-8"?><Response />`

I'm 90% confident this should work