### PR TITLE
Bump up twilio webhook timeout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -57,6 +57,7 @@ functions:
 
   twilioWebhook:
     handler: aws_lambdas/twilio_webhook.handler
+    timeout: 20
     events:
       - http:
           path: webhooks/twilio


### PR DESCRIPTION
This should never take this long... is bumping the timeout the right strategy? 

https://app.datadoghq.com/logs?cols=service&event=AQAAAXFhZjbJ-MBVawAAAABBWEZoWmowSWhVMVZJaXhiMnNBUw&from_ts=1586440204956&index=&live=true&messageDisplay=inline&query=-%22RequestID%22+-service%3Aeslworks-ml-prod-app+-status%3A%28warn+OR+info%29&stream_sort=desc&to_ts=1586526604956