### PR TITLE
stop double logging everything

### DIFF
--- a/stopcovid/utils/logging.py
+++ b/stopcovid/utils/logging.py
@@ -13,13 +13,3 @@ def configure_logging():
 
     root = logging.getLogger()
     root.setLevel(logging.INFO)
-
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(logging.INFO)
-    formatter = logging.Formatter(
-        "%(levelname)-8s %(asctime)s "
-        "%(filename)s:%(lineno)s - %(name)s - %(funcName)s: "
-        "%(message)s"
-    )
-    handler.setFormatter(formatter)
-    root.addHandler(handler)


### PR DESCRIPTION
each log message is getting sent twice to datadog. I imagine that the serverless framework is configuring a log handler that it forwards to DD so I'm disabling our hand-rolled handler.