### PR TITLE
use kinesis arrival for log message created_at

### DIFF
--- a/__tests__/stopcovid/sms/message_log/test_message_log.py
+++ b/__tests__/stopcovid/sms/message_log/test_message_log.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch
+import datetime
 
 from stopcovid.sms.message_log.types import LogMessageCommand, LogMessageCommandType
 from stopcovid.sms.message_log.message_log import log_messages
@@ -7,6 +8,9 @@ from stopcovid.sms.message_log.message_log import log_messages
 
 @patch("stopcovid.sms.message_log.message_log.persistence")
 class TestMessageLog(unittest.TestCase):
+    def _get_timestamp_min_in_past(self, min_ago):
+        return datetime.datetime.utcnow() - datetime.timedelta(minutes=min_ago)
+
     def test_calls_persistence_with_transformed_commands(self, persistence_mock):
         commands = [
             LogMessageCommand(
@@ -18,6 +22,7 @@ class TestMessageLog(unittest.TestCase):
                     "Body": "hello?",
                     "To": "+10009998888",
                 },
+                approximate_arrival=self._get_timestamp_min_in_past(5),
             ),
             LogMessageCommand(
                 command_type=LogMessageCommandType.STATUS_UPDATE,
@@ -27,6 +32,7 @@ class TestMessageLog(unittest.TestCase):
                     "From": "+1444333222",
                     "To": "+10009998888",
                 },
+                approximate_arrival=self._get_timestamp_min_in_past(3),
             ),
             LogMessageCommand(
                 command_type=LogMessageCommandType.OUTBOUND_SMS,
@@ -37,6 +43,7 @@ class TestMessageLog(unittest.TestCase):
                     "Body": "are you there?",
                     "To": "+10009998888",
                 },
+                approximate_arrival=self._get_timestamp_min_in_past(1),
             ),
         ]
         log_messages(commands)
@@ -47,12 +54,12 @@ class TestMessageLog(unittest.TestCase):
         upserts = [u for u in persistence_mock.mock_calls[1][1][0]]
         self.assertEqual(len(upserts), 3)
 
-        self.assertEqual(len(upserts[0].keys()), 5)
         self.assertEqual(upserts[0]["twilio_message_id"], commands[0].payload["MessageSid"])
         self.assertEqual(upserts[0]["from_number"], commands[0].payload["From"])
         self.assertEqual(upserts[0]["to_number"], commands[0].payload["To"])
         self.assertEqual(upserts[0]["status"], commands[0].payload["MessageStatus"])
         self.assertEqual(upserts[0]["body"], commands[0].payload["Body"])
+        self.assertEqual(upserts[0]["created_at"], commands[0].approximate_arrival)
 
         self.assertEqual(len(upserts[1].keys()), 4)
         self.assertEqual(upserts[1]["twilio_message_id"], commands[0].payload["MessageSid"])
@@ -60,9 +67,9 @@ class TestMessageLog(unittest.TestCase):
         self.assertEqual(upserts[1]["to_number"], commands[1].payload["To"])
         self.assertEqual(upserts[1]["status"], commands[1].payload["MessageStatus"])
 
-        self.assertEqual(len(upserts[2].keys()), 5)
         self.assertEqual(upserts[2]["twilio_message_id"], commands[2].payload["MessageSid"])
         self.assertEqual(upserts[2]["from_number"], commands[2].payload["From"])
         self.assertEqual(upserts[2]["to_number"], commands[2].payload["To"])
         self.assertEqual(upserts[2]["status"], commands[2].payload["MessageStatus"])
         self.assertEqual(upserts[2]["body"], commands[2].payload["Body"])
+        self.assertEqual(upserts[2]["created_at"], commands[2].approximate_arrival)

--- a/__tests__/stopcovid/sms/message_log/test_message_log.py
+++ b/__tests__/stopcovid/sms/message_log/test_message_log.py
@@ -1,16 +1,14 @@
 import unittest
 from unittest.mock import patch
-import datetime
 
 from stopcovid.sms.message_log.types import LogMessageCommand, LogMessageCommandType
 from stopcovid.sms.message_log.message_log import log_messages
 
+from __tests__.utils.time import get_timestamp_min_in_past
+
 
 @patch("stopcovid.sms.message_log.message_log.persistence")
 class TestMessageLog(unittest.TestCase):
-    def _get_timestamp_min_in_past(self, min_ago):
-        return datetime.datetime.utcnow() - datetime.timedelta(minutes=min_ago)
-
     def test_calls_persistence_with_transformed_commands(self, persistence_mock):
         commands = [
             LogMessageCommand(
@@ -22,7 +20,7 @@ class TestMessageLog(unittest.TestCase):
                     "Body": "hello?",
                     "To": "+10009998888",
                 },
-                approximate_arrival=self._get_timestamp_min_in_past(5),
+                approximate_arrival=get_timestamp_min_in_past(5),
             ),
             LogMessageCommand(
                 command_type=LogMessageCommandType.STATUS_UPDATE,
@@ -32,7 +30,7 @@ class TestMessageLog(unittest.TestCase):
                     "From": "+1444333222",
                     "To": "+10009998888",
                 },
-                approximate_arrival=self._get_timestamp_min_in_past(3),
+                approximate_arrival=get_timestamp_min_in_past(3),
             ),
             LogMessageCommand(
                 command_type=LogMessageCommandType.OUTBOUND_SMS,
@@ -43,7 +41,7 @@ class TestMessageLog(unittest.TestCase):
                     "Body": "are you there?",
                     "To": "+10009998888",
                 },
-                approximate_arrival=self._get_timestamp_min_in_past(1),
+                approximate_arrival=get_timestamp_min_in_past(1),
             ),
         ]
         log_messages(commands)

--- a/__tests__/stopcovid/sms/message_log/test_persistence.py
+++ b/__tests__/stopcovid/sms/message_log/test_persistence.py
@@ -1,19 +1,16 @@
 import unittest
-import datetime
 
 from stopcovid import db
 from stopcovid.sms.message_log.persistence import MessageRepository
 from sqlalchemy.exc import IntegrityError
+
+from __tests__.utils.time import get_timestamp_min_in_past
 
 
 class TestMessageRepository(unittest.TestCase):
     def setUp(self):
         self.repo = MessageRepository(db.get_test_sqlalchemy_engine)
         self.repo.drop_and_recreate_tables_testing_only()
-
-    def _get_timestamp_min_in_past(self, min_ago):
-        dt = datetime.datetime.now() - datetime.timedelta(minutes=min_ago)
-        return dt.replace(tzinfo=datetime.timezone.utc)
 
     def test_save_messages(self):
         messages = [
@@ -23,7 +20,7 @@ class TestMessageRepository(unittest.TestCase):
                 "to_number": "1113334444",
                 "body": "Good morning",
                 "status": "delivered",
-                "created_at": self._get_timestamp_min_in_past(5),
+                "created_at": get_timestamp_min_in_past(5),
             },
             {
                 "twilio_message_id": "twi-2",
@@ -31,7 +28,7 @@ class TestMessageRepository(unittest.TestCase):
                 "to_number": "1113334444",
                 "body": "Time for a new drill",
                 "status": "sent",
-                "created_at": self._get_timestamp_min_in_past(15),
+                "created_at": get_timestamp_min_in_past(15),
             },
         ]
         self.repo.upsert_messages(messages)

--- a/__tests__/stopcovid/sms/message_log/test_persistence.py
+++ b/__tests__/stopcovid/sms/message_log/test_persistence.py
@@ -86,6 +86,7 @@ class TestMessageRepository(unittest.TestCase):
                 "to_number": "1113334444",
                 "body": "Good morning",
                 "status": "sent",
+                "created_at": get_timestamp_min_in_past(10),
             },
         ]
 
@@ -97,6 +98,7 @@ class TestMessageRepository(unittest.TestCase):
         self.assertEqual(persisted_messages[0]["to_number"], "1113334444")
         self.assertEqual(persisted_messages[0]["body"], "Good morning")
         self.assertEqual(persisted_messages[0]["status"], "delivered")
+        self.assertEqual(persisted_messages[0]["created_at"], messages[1]["created_at"])
 
     def test_upsert_with_incomplete_data_on_insert(self):
         messages = [

--- a/__tests__/utils/time.py
+++ b/__tests__/utils/time.py
@@ -1,0 +1,6 @@
+import datetime
+
+
+def get_timestamp_min_in_past(min_ago: int) -> datetime.datetime:
+    dt = datetime.datetime.now() - datetime.timedelta(minutes=min_ago)
+    return dt.replace(tzinfo=datetime.timezone.utc)

--- a/stopcovid/sms/aws_lambdas/log_message.py
+++ b/stopcovid/sms/aws_lambdas/log_message.py
@@ -1,4 +1,5 @@
-from stopcovid.utils.kinesis import get_payloads_from_kinesis_event
+import datetime
+from stopcovid.utils.kinesis import get_payload_from_kinesis_record
 from stopcovid.sms.message_log.message_log import log_messages
 from stopcovid.sms.message_log.types import LogMessageCommandSchema
 
@@ -10,12 +11,22 @@ configure_logging()
 
 def handle(event, context):
     verify_deploy_stage()
-    raw_commands = get_payloads_from_kinesis_event(event)
-    commands = [
-        LogMessageCommandSchema().load(
-            {"command_type": command["type"], "payload": command["payload"]}
+    commands = []
+    for record in event["Records"]:
+        command = get_payload_from_kinesis_record(record)
+        approximate_arrival = (
+            datetime.datetime.fromtimestamp(record["kinesis"]["approximateArrivalTimestamp"])
+            .replace(tzinfo=datetime.timezone.utc)
+            .isoformat()
         )
-        for command in raw_commands
-    ]
+        commands.append(
+            LogMessageCommandSchema().load(
+                {
+                    "command_type": command["type"],
+                    "payload": command["payload"],
+                    "approximate_arrival": approximate_arrival,
+                }
+            )
+        )
     log_messages(commands)
     return {"statusCode": 200}

--- a/stopcovid/sms/message_log/message_log.py
+++ b/stopcovid/sms/message_log/message_log.py
@@ -19,6 +19,7 @@ def _command_to_dict(command: LogMessageCommand):
         "to_number": command.payload["To"],
         "status": command.payload.get("MessageStatus") or command.payload.get("SmsStatus"),
         "body": command.payload["Body"],
+        "created_at": command.approximate_arrival,
     }
 
 

--- a/stopcovid/sms/message_log/types.py
+++ b/stopcovid/sms/message_log/types.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from dataclasses import dataclass
 from marshmallow import Schema, fields, post_load
 
@@ -12,11 +13,13 @@ class LogMessageCommandType:
 class LogMessageCommand:
     command_type: str
     payload: dict
+    approximate_arrival: datetime
 
 
 class LogMessageCommandSchema(Schema):
     command_type = fields.Str(required=True)
     payload = fields.Dict(required=True)
+    approximate_arrival = fields.DateTime(required=True)
 
     @post_load
     def make_sms(self, data, **kwargs):


### PR DESCRIPTION
Release strategy:

1) Merge this
2) deploy dev
3) watch message log logs
4) remove now() default in aurora query editor
5) watch message log logs and validate that created_at is getting set still
6) repeat in prod