### PR TITLE
make inbound message flow transactional

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -122,6 +122,8 @@ functions:
             Fn::GetAtt:
               - MessageLogStream
               - Arn
+          startingPosition: LATEST
+          maximumRetryAttempts: 5
 
   distributeDialogEvents:
     handler: stopcovid/sms/aws_lambdas/enqueue_sms_batch.handler

--- a/serverless.yml
+++ b/serverless.yml
@@ -112,6 +112,17 @@ functions:
     handler: stopcovid/sms/aws_lambdas/log_message.handle
     timeout: 60  # Give aurora cluster time to cold start
 
+  publishProcessSMSCommands:
+    handler: stopcovid/sms/aws_lambdas/publish_process_sms_commands.handle
+    timeout: 20
+    events:
+      - stream:
+          type: kinesis
+          arn:
+            Fn::GetAtt:
+              - MessageLogStream
+              - Arn
+
   distributeDialogEvents:
     handler: stopcovid/sms/aws_lambdas/enqueue_sms_batch.handler
     events:

--- a/stopcovid/sms/aws_lambdas/publish_process_sms_commands.py
+++ b/stopcovid/sms/aws_lambdas/publish_process_sms_commands.py
@@ -1,0 +1,35 @@
+import logging
+
+from stopcovid.dialog.command_stream.publish import CommandPublisher
+from stopcovid.utils.idempotency import IdempotencyChecker
+from stopcovid.utils.kinesis import get_payload_from_kinesis_record
+
+from stopcovid.utils.logging import configure_logging
+from stopcovid.utils.verify_deploy_stage import verify_deploy_stage
+
+configure_logging()
+
+IDEMPOTENCY_REALM = "publish-process-sms"
+IDEMPOTENCY_EXPIRATION_MINUTES = 60
+
+
+def handle(event, context):
+    verify_deploy_stage()
+    records = event["Records"]
+    publisher = CommandPublisher()
+    idempotency_checker = IdempotencyChecker()
+    for record in records:
+        seq = record["kinesis"]["sequenceNumber"]
+        raw_command = get_payload_from_kinesis_record(record)
+        if raw_command["type"] == "INBOUND_SMS":
+            if not idempotency_checker.already_processed(seq, IDEMPOTENCY_REALM):
+                logging.info(
+                    f"Creating ProcessSMSMessage command for {raw_command['payload']['From']}"
+                )
+                publisher.publish_process_sms_command(
+                    raw_command["payload"]["From"], raw_command["payload"]["Body"]
+                )
+                idempotency_checker.record_as_processed(
+                    seq, IDEMPOTENCY_REALM, IDEMPOTENCY_EXPIRATION_MINUTES
+                )
+    return {"statusCode": 200}

--- a/stopcovid/sms/aws_lambdas/twilio_webhook.py
+++ b/stopcovid/sms/aws_lambdas/twilio_webhook.py
@@ -8,7 +8,6 @@ import boto3
 from twilio.request_validator import RequestValidator
 from twilio.twiml.messaging_response import MessagingResponse
 
-from stopcovid.dialog.command_stream.publish import CommandPublisher
 from stopcovid.utils.idempotency import IdempotencyChecker
 
 from stopcovid.utils.logging import configure_logging
@@ -43,9 +42,9 @@ def handler(event, context):
             StreamName=f"message-log-{stage}",
         )
     else:
-        logging.info(f"Inbound message from {form['From']}")
-        CommandPublisher().publish_process_sms_command(form["From"], form["Body"])
-        logging.info(f"Logging an INBOUND_SMS message in the message log")
+        logging.info(
+            f"Inbound message from {form['From']}. Recording INBOUND_SMS in the message log"
+        )
         kinesis.put_record(
             Data=json.dumps({"type": "INBOUND_SMS", "payload": form}),
             PartitionKey=form["From"],


### PR DESCRIPTION
The twilio webhook's sole responsibility is now to write to the message log stream. A second consumer of that stream will enqueue commands. This adds a bit of latency but makes it easier to reason about the impact of errors.

There will probably be a hiccup at rollout time - either dropping a message or double processing a message. I suggest we just roll with it.