### PR TITLE
check file versions without using threads

### DIFF
--- a/__tests__/stopcovid/drills/test_content_loader.py
+++ b/__tests__/stopcovid/drills/test_content_loader.py
@@ -1,5 +1,4 @@
 import unittest
-from time import sleep
 from unittest.mock import patch, MagicMock
 
 from stopcovid.drills.content_loader import S3Loader
@@ -22,15 +21,10 @@ class TestS3LoaderThreading(unittest.TestCase):
         boto3_patch = patch("stopcovid.drills.content_loader.boto3.resource", return_value=s3_mock)
         boto3_patch.start()
 
-        sleep_patch = patch("stopcovid.drills.content_loader.sleep")
-        sleep_patch.start()
-
         self.addCleanup(boto3_patch.stop)
-        self.addCleanup(sleep_patch.stop)
 
     def test_not_stale_content(self, populate_translations_patch, populate_drills_patch):
         loader = S3Loader("bucket-foo")
-        sleep(0.05)  # give polling thread time to run
         self.assertEqual(1, populate_translations_patch.call_count)
         self.assertEqual(1, populate_drills_patch.call_count)
         loader.get_all_drill_slugs()
@@ -42,11 +36,9 @@ class TestS3LoaderThreading(unittest.TestCase):
         self.assertEqual(1, populate_translations_patch.call_count)
         self.assertEqual(1, populate_drills_patch.call_count)
         self.version = "2"
-        sleep(0.05)  # give polling thread time to run
         loader.get_all_drill_slugs()
         self.assertEqual(2, populate_translations_patch.call_count)
         self.assertEqual(2, populate_drills_patch.call_count)
-        sleep(0.05)  # give polling thread time to run
         loader.get_all_drill_slugs()
         self.assertEqual(2, populate_translations_patch.call_count)
         self.assertEqual(2, populate_drills_patch.call_count)


### PR DESCRIPTION
we ask S3 to check the file version each time we need to pull drill content. We can back off or optimize if we need to